### PR TITLE
Changed xpath-react to handle composite components

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -5,5 +5,5 @@ engines:
 ratings:
   paths:
     - lib/**
-    - register.js
+    - index.js
     - utils.js

--- a/.eslintrc
+++ b/.eslintrc
@@ -12,7 +12,8 @@
   },
   "env": {
     "mocha": true,
-    "node": true
+    "node": true,
+    "browser": true
   },
   "extends": "eslint:recommended",
   "plugins": ["react"]

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,5 @@ env:
 script:
   - npm install xpath-evaluator
   - npm install react@$REACT_VERSION
-  - npm install react-addons-test-utils@$REACT_VERSION
   - make ci
 after_script: node_modules/.bin/codeclimate-test-reporter < coverage/lcov.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,7 @@ env:
 script:
   - npm install xpath-evaluator
   - npm install react@$REACT_VERSION
+  - npm install react-dom@$REACT_VERSION
+  - npm install react-addons-test-utils@$REACT_VERSION
   - make ci
 after_script: node_modules/.bin/codeclimate-test-reporter < coverage/lcov.info

--- a/index.js
+++ b/index.js
@@ -1,60 +1,8 @@
 "use strict";
 
 var XPathEvaluator = require("xpath-evaluator");
-var ReactInternals = require("./lib/ReactInternals");
 var XPathReactDocument = require("./lib/types/react_document");
 
 XPathEvaluator.setAdapter(XPathReactDocument);
 
-var XPathReact = {
-
-  XPathResult: XPathEvaluator.XPathResult,
-
-  evaluate: function(expression, element, nsResolver, type) {
-    return XPathEvaluator.evaluate(expression, element, nsResolver, type);
-  },
-
-  find: function(expression, element) {
-
-    var result = XPathReact.evaluate(expression, element, null, XPathReact.XPathResult.ANY_TYPE);
-
-    var results = [];
-    switch (result.resultType) {
-      case XPathReact.XPathResult.UNORDERED_NODE_ITERATOR_TYPE:
-        var el;
-        while (el = result.iterateNext()) {
-          results.push(el);
-        }
-        break;
-
-      case XPathReact.XPathResult.STRING_TYPE:
-        results.push(result.stringValue);
-        break;
-
-      case XPathReact.XPathResult.NUMBER_TYPE:
-        results.push(result.numberValue);
-        break;
-
-      case XPathReact.XPathResult.BOOLEAN_TYPE:
-        results.push(result.booleanValue);
-        break;
-    }
-
-    return results;
-
-  },
-
-  findReactRoot: function(path) {
-    var xpath = path || '//*[@data-reactroot]';
-    var xpathResult = document.evaluate(xpath, document, null, XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE, null);
-    if (xpathResult.snapshotLength == 0) {
-        throw 'No react application root was found with path ' + xpath;
-    } else if (xpathResult.snapshotLength > 1) {
-        throw 'Multiple react application roots were found with path ' + xpath;
-    }
-    return ReactInternals.findTopLevelCompositeComponentAtDOMNode(xpathResult.snapshotItem(0));
-  }
-
-};
-
-module.exports = XPathReact;
+module.exports = XPathEvaluator;

--- a/index.js
+++ b/index.js
@@ -1,0 +1,60 @@
+"use strict";
+
+var XPathEvaluator = require("xpath-evaluator");
+var ReactInternals = require("./lib/ReactInternals");
+var XPathReactDocument = require("./lib/types/react_document");
+
+XPathEvaluator.setAdapter(XPathReactDocument);
+
+var XPathReact = {
+
+  XPathResult: XPathEvaluator.XPathResult,
+
+  evaluate: function(expression, element, nsResolver, type) {
+    return XPathEvaluator.evaluate(expression, element, nsResolver, type);
+  },
+
+  find: function(expression, element) {
+
+    var result = XPathReact.evaluate(expression, element, null, XPathReact.XPathResult.ANY_TYPE);
+
+    var results = [];
+    switch (result.resultType) {
+      case XPathReact.XPathResult.UNORDERED_NODE_ITERATOR_TYPE:
+        var el;
+        while (el = result.iterateNext()) {
+          results.push(el);
+        }
+        break;
+
+      case XPathReact.XPathResult.STRING_TYPE:
+        results.push(result.stringValue);
+        break;
+
+      case XPathReact.XPathResult.NUMBER_TYPE:
+        results.push(result.numberValue);
+        break;
+
+      case XPathReact.XPathResult.BOOLEAN_TYPE:
+        results.push(result.booleanValue);
+        break;
+    }
+
+    return results;
+
+  },
+
+  findReactRoot: function(path) {
+    var xpath = path || '//*[@data-reactroot]';
+    var xpathResult = document.evaluate(xpath, document, null, XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE, null);
+    if (xpathResult.snapshotLength == 0) {
+        throw 'No react application root was found with path ' + xpath;
+    } else if (xpathResult.snapshotLength > 1) {
+        throw 'Multiple react application roots were found with path ' + xpath;
+    }
+    return ReactInternals.findTopLevelCompositeComponentAtDOMNode(xpathResult.snapshotItem(0));
+  }
+
+};
+
+module.exports = XPathReact;

--- a/lib/ReactInternals.js
+++ b/lib/ReactInternals.js
@@ -2,12 +2,17 @@
 
 var domReactInternalInstancePropertyKey = null;
 
+// from react/lib/ReactElementSymbol.js
 var REACT_ELEMENT_TYPE = typeof Symbol === "function" && Symbol.for && Symbol.for("react.element") || 0xeac7;
+// ----------
 
+// from react/lib/ReactElement.js
 function isValidElement(inst) {
   return typeof inst === "object" && inst !== null && inst.$$typeof === REACT_ELEMENT_TYPE;
 }
+// ----------
 
+// from react-dom/lib/ReactTestUtils.js
 function isDOMComponent(inst) {
   return !!(inst && inst.nodeType === 1 && inst.tagName);
 }
@@ -18,7 +23,9 @@ function isCompositeComponent(inst) {
   }
   return inst != null && typeof inst.render === "function" && typeof inst.setState === "function";
 }
+// ----------
 
+// deduced from browser and test data and react-dom/lib/ReactDOMComponentTree.js
 function getInternalInstance(inst) {
   if (isDOMComponent(inst)) {
     if (!domReactInternalInstancePropertyKey) {
@@ -44,11 +51,75 @@ function findTopLevelCompositeComponentAtDOMNode(dom) {
   var containerInfo = inst && (inst._nativeContainerInfo || inst._hostContainerInfo);
   return containerInfo && containerInfo._topLevelWrapper._renderedComponent.getPublicInstance();
 }
+// ----------
+
+// from react/lib/getIteratorFn.js
+var ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator;
+var FAUX_ITERATOR_SYMBOL = '@@iterator'; // Before Symbol spec.
+
+function getIteratorFn(maybeIterable) {
+  var iteratorFn = maybeIterable && (ITERATOR_SYMBOL && maybeIterable[ITERATOR_SYMBOL] || maybeIterable[FAUX_ITERATOR_SYMBOL]);
+  if (typeof iteratorFn === 'function') {
+    return iteratorFn;
+  }
+}
+// ----------
+
+// from react/lib/traverseAllChildren.js
+function forEachChild(children, callback, context) {
+  var type = typeof children;
+
+  if (type === 'undefined' || type === 'boolean') {
+    // All of the above are perceived as null.
+    children = null;
+  }
+
+  if (children === null || type === 'string' || type === 'number' ||
+  // The following is inlined from ReactElement. This means we can optimize
+  // some checks. React Fiber also inlines this logic for similar purposes.
+  type === 'object' && children.$$typeof === REACT_ELEMENT_TYPE) {
+    callback.call(context, children);
+    return;
+  }
+
+  var child;
+
+  if (Array.isArray(children)) {
+    for (var i = 0; i < children.length; i++) {
+      child = children[i];
+      forEachChild(child, callback, context);
+    }
+  } else {
+    var iteratorFn = getIteratorFn(children);
+    if (iteratorFn) {
+      var iterator = iteratorFn.call(children);
+      var step;
+      if (iteratorFn !== children.entries) {
+        var ii = 0;
+        while (!(step = iterator.next()).done) {
+          child = step.value;
+          forEachChild(child, callback, context);
+        }
+      } else {
+        // Iterator will provide entry [k,v] tuples rather than values.
+        while (!(step = iterator.next()).done) {
+          var entry = step.value;
+          if (entry) {
+            child = entry[1];
+            forEachChild(child, callback, context);
+          }
+        }
+      }
+    }
+  }
+}
+// ----------
 
 module.exports = {
   isValidElement: isValidElement,
   isDOMComponent: isDOMComponent,
   isCompositeComponent: isCompositeComponent,
   getInternalInstance: getInternalInstance,
-  findTopLevelCompositeComponentAtDOMNode: findTopLevelCompositeComponentAtDOMNode
+  findTopLevelCompositeComponentAtDOMNode: findTopLevelCompositeComponentAtDOMNode,
+  forEachChild: forEachChild
 };

--- a/lib/ReactInternals.js
+++ b/lib/ReactInternals.js
@@ -1,0 +1,49 @@
+"use strict";
+
+var domReactInternalInstancePropertyKey = null;
+
+var REACT_ELEMENT_TYPE = typeof Symbol === 'function' && Symbol['for'] && Symbol['for']('react.element') || 0xeac7;
+
+function isValidElement(object) {
+  return typeof object === 'object' && object !== null && object.$$typeof === REACT_ELEMENT_TYPE;
+}
+
+function isDOMComponent(inst) {
+  return !!(inst && inst.nodeType === 1 && inst.tagName);
+}
+
+function isCompositeComponent(inst) {
+  if (isDOMComponent(inst)) {
+    return false;
+  }
+  return inst != null && typeof inst.render === 'function' && typeof inst.setState === 'function';
+}
+
+function getInternalInstance(inst) {
+  if (isDOMComponent(inst)) {
+    if (!domReactInternalInstancePropertyKey) {
+      for (var key in inst) {
+        if (key.startsWith("__reactInternalInstance$")) {
+          domReactInternalInstancePropertyKey = key;
+          break;
+        }
+      }
+    }
+    return inst[domReactInternalInstancePropertyKey];
+  } else if (isCompositeComponent(inst)) {
+    return inst._reactInternalInstance;
+  }
+}
+
+function findTopLevelCompositeComponentAtDOMNode(dom) {
+    var inst = getInternalInstance(dom);
+    return inst && inst._nativeContainerInfo && inst._nativeContainerInfo._topLevelWrapper._renderedComponent.getPublicInstance();
+}
+
+module.exports = {
+  isValidElement: isValidElement,
+  isDOMComponent: isDOMComponent,
+  isCompositeComponent: isCompositeComponent,
+  getInternalInstance: getInternalInstance,
+  findTopLevelCompositeComponentAtDOMNode: findTopLevelCompositeComponentAtDOMNode
+};

--- a/lib/ReactInternals.js
+++ b/lib/ReactInternals.js
@@ -2,10 +2,10 @@
 
 var domReactInternalInstancePropertyKey = null;
 
-var REACT_ELEMENT_TYPE = typeof Symbol === 'function' && Symbol['for'] && Symbol['for']('react.element') || 0xeac7;
+var REACT_ELEMENT_TYPE = typeof Symbol === "function" && Symbol["for"] && Symbol["for"]("react.element") || 0xeac7;
 
 function isValidElement(object) {
-  return typeof object === 'object' && object !== null && object.$$typeof === REACT_ELEMENT_TYPE;
+  return typeof object === "object" && object !== null && object.$$typeof === REACT_ELEMENT_TYPE;
 }
 
 function isDOMComponent(inst) {
@@ -16,7 +16,7 @@ function isCompositeComponent(inst) {
   if (isDOMComponent(inst)) {
     return false;
   }
-  return inst != null && typeof inst.render === 'function' && typeof inst.setState === 'function';
+  return inst != null && typeof inst.render === "function" && typeof inst.setState === "function";
 }
 
 function getInternalInstance(inst) {
@@ -36,9 +36,9 @@ function getInternalInstance(inst) {
 }
 
 function findTopLevelCompositeComponentAtDOMNode(dom) {
-    var inst = getInternalInstance(dom);
-    var containerInfo = inst && (inst._nativeContainerInfo || inst && inst._hostContainerInfo);
-    return containerInfo && containerInfo._topLevelWrapper._renderedComponent.getPublicInstance();
+  var inst = getInternalInstance(dom);
+  var containerInfo = inst && (inst._nativeContainerInfo || inst && inst._hostContainerInfo);
+  return containerInfo && containerInfo._topLevelWrapper._renderedComponent.getPublicInstance();
 }
 
 module.exports = {

--- a/lib/ReactInternals.js
+++ b/lib/ReactInternals.js
@@ -4,8 +4,8 @@ var domReactInternalInstancePropertyKey = null;
 
 var REACT_ELEMENT_TYPE = typeof Symbol === "function" && Symbol["for"] && Symbol["for"]("react.element") || 0xeac7;
 
-function isValidElement(object) {
-  return typeof object === "object" && object !== null && object.$$typeof === REACT_ELEMENT_TYPE;
+function isValidElement(inst) {
+  return typeof inst === "object" && inst !== null && inst.$$typeof === REACT_ELEMENT_TYPE;
 }
 
 function isDOMComponent(inst) {

--- a/lib/ReactInternals.js
+++ b/lib/ReactInternals.js
@@ -26,7 +26,7 @@ function isCompositeComponent(inst) {
 // ----------
 
 // deduced from browser and test data and react-dom/lib/ReactDOMComponentTree.js
-function getInternalInstance(inst) {
+function getDOMInternalInstance(inst) {
   if (isDOMComponent(inst)) {
     if (!domReactInternalInstancePropertyKey) {
       for (var key in inst) {
@@ -37,8 +37,6 @@ function getInternalInstance(inst) {
       }
     }
     return inst[domReactInternalInstancePropertyKey];
-  } else if (isCompositeComponent(inst)) {
-    return inst._reactInternalInstance;
   }
 }
 
@@ -47,7 +45,7 @@ function findTopLevelCompositeComponentAtDOMNode(dom) {
     return null;
   }
 
-  var inst = getInternalInstance(dom);
+  var inst = getDOMInternalInstance(dom);
   var containerInfo = inst && (inst._nativeContainerInfo || inst._hostContainerInfo);
   return containerInfo && containerInfo._topLevelWrapper._renderedComponent.getPublicInstance();
 }
@@ -118,7 +116,7 @@ module.exports = {
   isValidElement: isValidElement,
   isDOMComponent: isDOMComponent,
   isCompositeComponent: isCompositeComponent,
-  getInternalInstance: getInternalInstance,
+  getDOMInternalInstance: getDOMInternalInstance,
   findTopLevelCompositeComponentAtDOMNode: findTopLevelCompositeComponentAtDOMNode,
   forEachChild: forEachChild
 };

--- a/lib/ReactInternals.js
+++ b/lib/ReactInternals.js
@@ -54,12 +54,12 @@ function findTopLevelCompositeComponentAtDOMNode(dom) {
 // ----------
 
 // from react/lib/getIteratorFn.js
-var ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator;
-var FAUX_ITERATOR_SYMBOL = '@@iterator'; // Before Symbol spec.
+var ITERATOR_SYMBOL = typeof Symbol === "function" && Symbol.iterator;
+var FAUX_ITERATOR_SYMBOL = "@@iterator"; // Before Symbol spec.
 
 function getIteratorFn(maybeIterable) {
   var iteratorFn = maybeIterable && (ITERATOR_SYMBOL && maybeIterable[ITERATOR_SYMBOL] || maybeIterable[FAUX_ITERATOR_SYMBOL]);
-  if (typeof iteratorFn === 'function') {
+  if (typeof iteratorFn === "function") {
     return iteratorFn;
   }
 }
@@ -69,15 +69,15 @@ function getIteratorFn(maybeIterable) {
 function forEachChild(children, callback, context) {
   var type = typeof children;
 
-  if (type === 'undefined' || type === 'boolean') {
+  if (type === "undefined" || type === "boolean") {
     // All of the above are perceived as null.
     children = null;
   }
 
-  if (children === null || type === 'string' || type === 'number' ||
+  if (children === null || type === "string" || type === "number" ||
   // The following is inlined from ReactElement. This means we can optimize
   // some checks. React Fiber also inlines this logic for similar purposes.
-  type === 'object' && children.$$typeof === REACT_ELEMENT_TYPE) {
+  type === "object" && children.$$typeof === REACT_ELEMENT_TYPE) {
     callback.call(context, children);
     return;
   }
@@ -95,7 +95,6 @@ function forEachChild(children, callback, context) {
       var iterator = iteratorFn.call(children);
       var step;
       if (iteratorFn !== children.entries) {
-        var ii = 0;
         while (!(step = iterator.next()).done) {
           child = step.value;
           forEachChild(child, callback, context);

--- a/lib/ReactInternals.js
+++ b/lib/ReactInternals.js
@@ -1,7 +1,5 @@
 "use strict";
 
-var domReactInternalInstancePropertyKey = null;
-
 // from react/lib/ReactElementSymbol.js
 var REACT_ELEMENT_TYPE = typeof Symbol === "function" && Symbol.for && Symbol.for("react.element") || 0xeac7;
 // ----------
@@ -25,7 +23,9 @@ function isCompositeComponent(inst) {
 }
 // ----------
 
-// deduced from browser and test data and react-dom/lib/ReactDOMComponentTree.js
+// deduced from react-dom/lib/ReactDOMComponentTree.js
+var domReactInternalInstancePropertyKey = null;
+
 function getDOMInternalInstance(inst) {
   if (isDOMComponent(inst)) {
     if (!domReactInternalInstancePropertyKey) {
@@ -39,7 +39,9 @@ function getDOMInternalInstance(inst) {
     return inst[domReactInternalInstancePropertyKey];
   }
 }
+// ----------
 
+// deduced from inspecting browser and test react objects
 function findTopLevelCompositeComponentAtDOMNode(dom) {
   if (!dom) {
     return null;

--- a/lib/ReactInternals.js
+++ b/lib/ReactInternals.js
@@ -37,7 +37,8 @@ function getInternalInstance(inst) {
 
 function findTopLevelCompositeComponentAtDOMNode(dom) {
     var inst = getInternalInstance(dom);
-    return inst && inst._nativeContainerInfo && inst._nativeContainerInfo._topLevelWrapper._renderedComponent.getPublicInstance();
+    var containerInfo = inst && (inst._nativeContainerInfo || inst && inst._hostContainerInfo);
+    return containerInfo && containerInfo._topLevelWrapper._renderedComponent.getPublicInstance();
 }
 
 module.exports = {

--- a/lib/ReactInternals.js
+++ b/lib/ReactInternals.js
@@ -2,7 +2,7 @@
 
 var domReactInternalInstancePropertyKey = null;
 
-var REACT_ELEMENT_TYPE = typeof Symbol === "function" && Symbol["for"] && Symbol["for"]("react.element") || 0xeac7;
+var REACT_ELEMENT_TYPE = typeof Symbol === "function" && Symbol.for && Symbol.for("react.element") || 0xeac7;
 
 function isValidElement(inst) {
   return typeof inst === "object" && inst !== null && inst.$$typeof === REACT_ELEMENT_TYPE;
@@ -36,8 +36,12 @@ function getInternalInstance(inst) {
 }
 
 function findTopLevelCompositeComponentAtDOMNode(dom) {
+  if (!dom) {
+    return null;
+  }
+
   var inst = getInternalInstance(dom);
-  var containerInfo = inst && (inst._nativeContainerInfo || inst && inst._hostContainerInfo);
+  var containerInfo = inst && (inst._nativeContainerInfo || inst._hostContainerInfo);
   return containerInfo && containerInfo._topLevelWrapper._renderedComponent.getPublicInstance();
 }
 

--- a/lib/types/react_attribute.js
+++ b/lib/types/react_attribute.js
@@ -2,50 +2,50 @@
 
 var XPathEvaluator = require("xpath-evaluator");
 
-function XPathReactAttribute (attributeName, textContent, parent, nChild) {
+function XPathReactAttribute(attributeName, textContent, parent, nChild) {
   this.attributeName = attributeName;
   this.textContent = textContent;
   this.parent = parent;
   this.nChild = nChild;
 }
 
-XPathReactAttribute.prototype.getId = function () {
+XPathReactAttribute.prototype.getId = function() {
   return this.getParent().getId() + "." + this.nChild;
 };
 
-XPathReactAttribute.prototype.isEqual = function (node) {
+XPathReactAttribute.prototype.isEqual = function(node) {
   return this.getId() === node.getId();
 };
 
-XPathReactAttribute.prototype.asString = function () {
+XPathReactAttribute.prototype.asString = function() {
   return this.textContent;
 };
 
-XPathReactAttribute.prototype.asNumber = function () {
+XPathReactAttribute.prototype.asNumber = function() {
   return +this.asString();
 };
 
-XPathReactAttribute.prototype.getNodeType = function () {
+XPathReactAttribute.prototype.getNodeType = function() {
   return XPathEvaluator.Node.ATTRIBUTE_NODE;
 };
 
-XPathReactAttribute.prototype.getParent = function () {
+XPathReactAttribute.prototype.getParent = function() {
   return this.parent;
 };
 
-XPathReactAttribute.prototype.getChildNodes = function () {
+XPathReactAttribute.prototype.getChildNodes = function() {
   return undefined;
 };
 
-XPathReactAttribute.prototype.getFollowingSiblings = function () {
+XPathReactAttribute.prototype.getFollowingSiblings = function() {
   return undefined;
 };
 
-XPathReactAttribute.prototype.getPrecedingSiblings = function () {
+XPathReactAttribute.prototype.getPrecedingSiblings = function() {
   return undefined;
 };
 
-XPathReactAttribute.prototype.getName = function () {
+XPathReactAttribute.prototype.getName = function() {
   switch (this.attributeName) {
     case "className":
       return "class";
@@ -56,15 +56,15 @@ XPathReactAttribute.prototype.getName = function () {
   }
 };
 
-XPathReactAttribute.prototype.getAttributes = function () {
+XPathReactAttribute.prototype.getAttributes = function() {
   return undefined;
 };
 
-XPathReactAttribute.prototype.getOwnerDocument = function () {
+XPathReactAttribute.prototype.getOwnerDocument = function() {
   return this.getParent().getOwnerDocument();
 };
 
-XPathReactAttribute.prototype.toString = function () {
+XPathReactAttribute.prototype.toString = function() {
   return "Node<" + this.attributeName + ">";
 };
 

--- a/lib/types/react_attribute.js
+++ b/lib/types/react_attribute.js
@@ -2,50 +2,50 @@
 
 var XPathEvaluator = require("xpath-evaluator");
 
-function ReactAttribute (attributeName, textContent, parent, nChild) {
+function XPathReactAttribute (attributeName, textContent, parent, nChild) {
   this.attributeName = attributeName;
   this.textContent = textContent;
   this.parent = parent;
   this.nChild = nChild;
 }
 
-ReactAttribute.prototype.getId = function () {
+XPathReactAttribute.prototype.getId = function () {
   return this.getParent().getId() + "." + this.nChild;
 };
 
-ReactAttribute.prototype.isEqual = function (node) {
+XPathReactAttribute.prototype.isEqual = function (node) {
   return this.getId() === node.getId();
 };
 
-ReactAttribute.prototype.asString = function () {
+XPathReactAttribute.prototype.asString = function () {
   return this.textContent;
 };
 
-ReactAttribute.prototype.asNumber = function () {
+XPathReactAttribute.prototype.asNumber = function () {
   return +this.asString();
 };
 
-ReactAttribute.prototype.getNodeType = function () {
+XPathReactAttribute.prototype.getNodeType = function () {
   return XPathEvaluator.Node.ATTRIBUTE_NODE;
 };
 
-ReactAttribute.prototype.getParent = function () {
+XPathReactAttribute.prototype.getParent = function () {
   return this.parent;
 };
 
-ReactAttribute.prototype.getChildNodes = function () {
+XPathReactAttribute.prototype.getChildNodes = function () {
   return undefined;
 };
 
-ReactAttribute.prototype.getFollowingSiblings = function () {
+XPathReactAttribute.prototype.getFollowingSiblings = function () {
   return undefined;
 };
 
-ReactAttribute.prototype.getPrecedingSiblings = function () {
+XPathReactAttribute.prototype.getPrecedingSiblings = function () {
   return undefined;
 };
 
-ReactAttribute.prototype.getName = function () {
+XPathReactAttribute.prototype.getName = function () {
   switch (this.attributeName) {
     case "className":
       return "class";
@@ -56,16 +56,16 @@ ReactAttribute.prototype.getName = function () {
   }
 };
 
-ReactAttribute.prototype.getAttributes = function () {
+XPathReactAttribute.prototype.getAttributes = function () {
   return undefined;
 };
 
-ReactAttribute.prototype.getOwnerDocument = function () {
+XPathReactAttribute.prototype.getOwnerDocument = function () {
   return this.getParent().getOwnerDocument();
 };
 
-ReactAttribute.prototype.toString = function () {
+XPathReactAttribute.prototype.toString = function () {
   return "Node<" + this.attributeName + ">";
 };
 
-module.exports = ReactAttribute;
+module.exports = XPathReactAttribute;

--- a/lib/types/react_document.js
+++ b/lib/types/react_document.js
@@ -1,78 +1,77 @@
 "use strict";
 
-var TestUtils = require("react-addons-test-utils");
-
+var ReactInternals = require("../ReactInternals");
 var XPathEvaluator = require("xpath-evaluator");
 
-var ReactElement = require("./react_element");
+var XPathReactElement = require("./react_element");
 
-function ReactDocument (nativeNode) {
-  if (!TestUtils.isElement(nativeNode)) {
-    throw new Error("Expected a React element");
+function XPathReactDocument (nativeNode) {
+    if (!ReactInternals.isValidElement(nativeNode) && !ReactInternals.isCompositeComponent(nativeNode)) {
+    throw "Expected a React element or composite component";
   }
 
-  this.elementNode = new ReactElement(nativeNode, this, 0);
+  this.elementNode = new XPathReactElement(nativeNode, this, 0);
 }
 
-ReactDocument.prototype.getId = function () {
+XPathReactDocument.prototype.getId = function () {
   return "0";
 };
 
-ReactDocument.prototype.isEqual = function (node) {
+XPathReactDocument.prototype.isEqual = function (node) {
   return this.getId() === node.getId();
 };
 
-ReactDocument.prototype.getNativeNode = function () {
+XPathReactDocument.prototype.getNativeNode = function () {
   throw new Error("Accessing the abstract document node is not allowed");
 };
 
-ReactDocument.prototype.asString = function () {
+XPathReactDocument.prototype.asString = function () {
   return this.elementNode.asString();
 };
 
-ReactDocument.prototype.asNumber = function () {
+XPathReactDocument.prototype.asNumber = function () {
   return +this.asString();
 };
 
-ReactDocument.prototype.getNodeType = function () {
+XPathReactDocument.prototype.getNodeType = function () {
   return XPathEvaluator.Node.DOCUMENT_NODE;
 };
 
-ReactDocument.prototype.getChildNodes = function () {
+XPathReactDocument.prototype.getChildNodes = function () {
   return [this.elementNode];
 };
 
-ReactDocument.prototype.getFollowingSiblings = function () {
+XPathReactDocument.prototype.getFollowingSiblings = function () {
   return undefined;
 };
 
-ReactDocument.prototype.getPrecedingSiblings = function () {
+XPathReactDocument.prototype.getPrecedingSiblings = function () {
   return undefined;
 };
 
-ReactDocument.prototype.getName = function () {
+XPathReactDocument.prototype.getName = function () {
   return undefined;
 };
 
-ReactDocument.prototype.getAttributes = function () {
+XPathReactDocument.prototype.getAttributes = function () {
   return undefined;
 };
 
-ReactDocument.prototype.getOwnerDocument = function () {
+XPathReactDocument.prototype.getOwnerDocument = function () {
   return undefined;
 };
 
-ReactDocument.prototype.getElementById = function (id) {
+XPathReactDocument.prototype.getElementById = function (id) {
   /* eslint-disable no-underscore-dangle */
   return this.elementNode._getElementById(id);
   /* eslint-enable no-underscore-dangle */
 };
 
-ReactDocument.prototype.toString = function () {
+XPathReactDocument.prototype.toString = function () {
   return "Node<document>";
 };
 
-ReactDocument.compareDocumentPosition = function (a, b) {
+XPathReactDocument.compareDocumentPosition = function (a, b) {
   a = a.getId();
   b = b.getId();
 
@@ -105,4 +104,4 @@ ReactDocument.compareDocumentPosition = function (a, b) {
   return -1;
 };
 
-module.exports = ReactDocument;
+module.exports = XPathReactDocument;

--- a/lib/types/react_document.js
+++ b/lib/types/react_document.js
@@ -5,72 +5,72 @@ var XPathEvaluator = require("xpath-evaluator");
 
 var XPathReactElement = require("./react_element");
 
-function XPathReactDocument (nativeNode) {
+function XPathReactDocument(nativeNode) {
   if (!ReactInternals.isValidElement(nativeNode) && !ReactInternals.isCompositeComponent(nativeNode)) {
     throw "Expected a React element or composite component";
   }
   this.elementNode = new XPathReactElement(nativeNode, this, 0);
 }
 
-XPathReactDocument.prototype.getId = function () {
+XPathReactDocument.prototype.getId = function() {
   return "0";
 };
 
-XPathReactDocument.prototype.isEqual = function (node) {
+XPathReactDocument.prototype.isEqual = function(node) {
   return this.getId() === node.getId();
 };
 
-XPathReactDocument.prototype.getNativeNode = function () {
+XPathReactDocument.prototype.getNativeNode = function() {
   throw new Error("Accessing the abstract document node is not allowed");
 };
 
-XPathReactDocument.prototype.asString = function () {
+XPathReactDocument.prototype.asString = function() {
   return this.elementNode.asString();
 };
 
-XPathReactDocument.prototype.asNumber = function () {
+XPathReactDocument.prototype.asNumber = function() {
   return +this.asString();
 };
 
-XPathReactDocument.prototype.getNodeType = function () {
+XPathReactDocument.prototype.getNodeType = function() {
   return XPathEvaluator.Node.DOCUMENT_NODE;
 };
 
-XPathReactDocument.prototype.getChildNodes = function () {
+XPathReactDocument.prototype.getChildNodes = function() {
   return [this.elementNode];
 };
 
-XPathReactDocument.prototype.getFollowingSiblings = function () {
+XPathReactDocument.prototype.getFollowingSiblings = function() {
   return undefined;
 };
 
-XPathReactDocument.prototype.getPrecedingSiblings = function () {
+XPathReactDocument.prototype.getPrecedingSiblings = function() {
   return undefined;
 };
 
-XPathReactDocument.prototype.getName = function () {
+XPathReactDocument.prototype.getName = function() {
   return undefined;
 };
 
-XPathReactDocument.prototype.getAttributes = function () {
+XPathReactDocument.prototype.getAttributes = function() {
   return undefined;
 };
 
-XPathReactDocument.prototype.getOwnerDocument = function () {
+XPathReactDocument.prototype.getOwnerDocument = function() {
   return undefined;
 };
 
-XPathReactDocument.prototype.getElementById = function (id) {
+XPathReactDocument.prototype.getElementById = function(id) {
   /* eslint-disable no-underscore-dangle */
   return this.elementNode._getElementById(id);
   /* eslint-enable no-underscore-dangle */
 };
 
-XPathReactDocument.prototype.toString = function () {
+XPathReactDocument.prototype.toString = function() {
   return "Node<document>";
 };
 
-XPathReactDocument.compareDocumentPosition = function (a, b) {
+XPathReactDocument.compareDocumentPosition = function(a, b) {
   a = a.getId();
   b = b.getId();
 
@@ -78,11 +78,11 @@ XPathReactDocument.compareDocumentPosition = function (a, b) {
     return 0;
   }
 
-  a = a.split(".").map(function (number) {
+  a = a.split(".").map(function(number) {
     return parseInt(number, 10);
   });
 
-  b = b.split(".").map(function (number) {
+  b = b.split(".").map(function(number) {
     return parseInt(number, 10);
   });
 

--- a/lib/types/react_document.js
+++ b/lib/types/react_document.js
@@ -6,7 +6,7 @@ var XPathEvaluator = require("xpath-evaluator");
 var XPathReactElement = require("./react_element");
 
 function XPathReactDocument (nativeNode) {
-    if (!ReactInternals.isValidElement(nativeNode) && !ReactInternals.isCompositeComponent(nativeNode)) {
+  if (!ReactInternals.isValidElement(nativeNode) && !ReactInternals.isCompositeComponent(nativeNode)) {
     throw "Expected a React element or composite component";
   }
   this.elementNode = new XPathReactElement(nativeNode, this, 0);

--- a/lib/types/react_document.js
+++ b/lib/types/react_document.js
@@ -9,7 +9,6 @@ function XPathReactDocument (nativeNode) {
     if (!ReactInternals.isValidElement(nativeNode) && !ReactInternals.isCompositeComponent(nativeNode)) {
     throw "Expected a React element or composite component";
   }
-
   this.elementNode = new XPathReactElement(nativeNode, this, 0);
 }
 

--- a/lib/types/react_element.js
+++ b/lib/types/react_element.js
@@ -55,13 +55,13 @@ XPathReactElement.prototype.getParent = function () {
 };
 
 XPathReactElement.prototype.getChildNodes = function () {
+  var children = [];
   if (ReactInternals.isDOMComponent(this.nativeNode)) {
-    var internalInstance = ReactInternals.getInternalInstance(this.nativeNode);
-    if (internalInstance._renderedChildren) {
-      var renderedChildren = internalInstance._renderedChildren;
+    var domInternalInstance = ReactInternals.getInternalInstance(this.nativeNode);
+    if (domInternalInstance._renderedChildren) {
+      var renderedChildren = domInternalInstance._renderedChildren;
   
-      var children = [];
-      for (var key in internalInstance._renderedChildren) {
+      for (var key in domInternalInstance._renderedChildren) {
         if (!renderedChildren.hasOwnProperty(key) || !renderedChildren[key]) {
           continue;
         }
@@ -72,29 +72,21 @@ XPathReactElement.prototype.getChildNodes = function () {
           children.push(new XPathReactElement(renderedChildren[key].getPublicInstance(), this, children.length));
         }
       }
-      return children;
 
-    } else if (internalInstance._currentElement.props && internalInstance._currentElement.props.children) {
-      var children = [];
-      React.Children.forEach(internalInstance._currentElement.props.children, function(child) {
+    } else if (domInternalInstance._currentElement.props && domInternalInstance._currentElement.props.children) {
+      React.Children.forEach(domInternalInstance._currentElement.props.children, function(child) {
         children.push(new XPathReactText(child, this, children.length));
       }.bind(this));
-      return children;
 
-    } else {
-      return [];
     }
 
   } else if (ReactInternals.isCompositeComponent(this.nativeNode)) {
     var internalInstance = ReactInternals.getInternalInstance(this.nativeNode);
     if (internalInstance._renderedComponent) {
-      return [new XPathReactElement(internalInstance._renderedComponent.getPublicInstance(), this, 0)];
-    } else {
-      return [];
+      children.push(new XPathReactElement(internalInstance._renderedComponent.getPublicInstance(), this, 0));
     }
 
   } else if (this.nativeNode.props && this.nativeNode.props.children) {
-    var children = [];
     React.Children.forEach(this.nativeNode.props.children, function(child) {
       if (typeof child === "string") {
         children.push(new XPathReactText(child, this, children.length));
@@ -102,11 +94,9 @@ XPathReactElement.prototype.getChildNodes = function () {
         children.push(new XPathReactElement(child, this, children.length));
       }
     }.bind(this));
-    return children;
-
-  } else {
-    return [];
   } 
+
+  return children;
 };
 
 XPathReactElement.prototype.getFollowingSiblings = function () {

--- a/lib/types/react_element.js
+++ b/lib/types/react_element.js
@@ -148,8 +148,8 @@ XPathReactElement.prototype.getAttributes = function () {
   var i = 0;
 
   if (ReactInternals.isDOMComponent(this.nativeNode)) {
-    var internalInstance = ReactInternals.getInternalInstance(this.nativeNode);
-    props = internalInstance._currentElement.props;
+    var domInternalInstance = ReactInternals.getInternalInstance(this.nativeNode);
+    props = domInternalInstance._currentElement.props;
 
   } else if (ReactInternals.isCompositeComponent(this.nativeNode)) {
     var internalInstance = ReactInternals.getInternalInstance(this.nativeNode);

--- a/lib/types/react_element.js
+++ b/lib/types/react_element.js
@@ -167,13 +167,14 @@ XPathReactElement.prototype.getAttributes = function () {
     if (key) {
       attributes.push(new XPathReactAttribute("key", key, this, i++));
     }
+    props = internalInstance._currentElement.props;
 
   } else {
     props = this.nativeNode.props;
   }
 
   if (!props) {
-    return [];
+    return attributes;
   }
 
   for (var attribute in props) {

--- a/lib/types/react_element.js
+++ b/lib/types/react_element.js
@@ -6,21 +6,21 @@ var XPathEvaluator = require("xpath-evaluator");
 var XPathReactAttribute = require("./react_attribute");
 var XPathReactText = require("./react_text");
 
-function XPathReactElement (nativeNode, parent, nChild) {
+function XPathReactElement(nativeNode, parent, nChild) {
   this.nativeNode = nativeNode;
   this.parent = parent;
   this.nChild = nChild;
 }
 
-XPathReactElement.prototype.getId = function () {
+XPathReactElement.prototype.getId = function() {
   return this.getParent().getId() + "." + this.nChild;
 };
 
-XPathReactElement.prototype.isEqual = function (node) {
+XPathReactElement.prototype.isEqual = function(node) {
   return this.getId() === node.getId();
 };
 
-XPathReactElement.prototype.getNativeNode = function () {
+XPathReactElement.prototype.getNativeNode = function() {
   if (ReactInternals.isCompositeComponent(this.nativeNode)) {
     return this.nativeNode._reactInternalInstance && this.nativeNode._reactInternalInstance._currentElement;
   } else {
@@ -28,10 +28,10 @@ XPathReactElement.prototype.getNativeNode = function () {
   }
 };
 
-XPathReactElement.prototype.asString = function () {
+XPathReactElement.prototype.asString = function() {
   var textContent = "";
 
-  this.getChildNodes().forEach(function (child) {
+  this.getChildNodes().forEach(function(child) {
     if (child.getNodeType() === XPathEvaluator.Node.ELEMENT_NODE || child.getNodeType() === XPathEvaluator.Node.TEXT_NODE) {
       textContent = textContent + child.asString();
     }
@@ -40,19 +40,19 @@ XPathReactElement.prototype.asString = function () {
   return textContent;
 };
 
-XPathReactElement.prototype.asNumber = function () {
+XPathReactElement.prototype.asNumber = function() {
   return +this.asString();
 };
 
-XPathReactElement.prototype.getNodeType = function () {
+XPathReactElement.prototype.getNodeType = function() {
   return XPathEvaluator.Node.ELEMENT_NODE;
 };
 
-XPathReactElement.prototype.getParent = function () {
+XPathReactElement.prototype.getParent = function() {
   return this.parent;
 };
 
-XPathReactElement.prototype.getChildNodes = function () {
+XPathReactElement.prototype.getChildNodes = function() {
   var children = [];
   if (ReactInternals.isDOMComponent(this.nativeNode)) {
     var domInternalInstance = ReactInternals.getInternalInstance(this.nativeNode);
@@ -67,7 +67,7 @@ XPathReactElement.prototype.getChildNodes = function () {
         if (renderedChildren[key]._stringText) {
           children.push(new XPathReactText(renderedChildren[key]._stringText, this, children.length));
         } else {
-          children.push(new XPathReactElement(renderedChildren[key].getPublicInstance(), this, children.length));
+          children.push(new XPathReactElement(renderedChildren[key].getPublicInstance() || renderedChildren[key]._currentElement, this, children.length));
         }
       }
 
@@ -81,7 +81,7 @@ XPathReactElement.prototype.getChildNodes = function () {
   } else if (ReactInternals.isCompositeComponent(this.nativeNode)) {
     var internalInstance = ReactInternals.getInternalInstance(this.nativeNode);
     if (internalInstance._renderedComponent) {
-      children.push(new XPathReactElement(internalInstance._renderedComponent.getPublicInstance(), this, 0));
+      children.push(new XPathReactElement(internalInstance._renderedComponent.getPublicInstance()  || internalInstance._renderedComponent._currentElement, this, 0));
     }
 
   } else if (this.nativeNode.props && this.nativeNode.props.children) {
@@ -97,12 +97,12 @@ XPathReactElement.prototype.getChildNodes = function () {
   return children;
 };
 
-XPathReactElement.prototype.getFollowingSiblings = function () {
+XPathReactElement.prototype.getFollowingSiblings = function() {
   var followingSiblings = [];
 
   var siblings = this.getParent().getChildNodes();
 
-  var thisSiblingIndex = siblings.findIndex(function (sibling) {
+  var thisSiblingIndex = siblings.findIndex(function(sibling) {
     return sibling.isEqual(this);
   }.bind(this));
 
@@ -113,12 +113,12 @@ XPathReactElement.prototype.getFollowingSiblings = function () {
   return followingSiblings;
 };
 
-XPathReactElement.prototype.getPrecedingSiblings = function () {
+XPathReactElement.prototype.getPrecedingSiblings = function() {
   var precedingSiblings = [];
 
   var siblings = this.getParent().getChildNodes();
 
-  var thisSiblingIndex = siblings.findIndex(function (sibling) {
+  var thisSiblingIndex = siblings.findIndex(function(sibling) {
     return sibling.isEqual(this);
   }.bind(this));
 
@@ -129,7 +129,7 @@ XPathReactElement.prototype.getPrecedingSiblings = function () {
   return precedingSiblings;
 };
 
-XPathReactElement.prototype.getName = function () {
+XPathReactElement.prototype.getName = function() {
   var el = this.getNativeNode();
   if (ReactInternals.isDOMComponent(el)) {
     return el.localName;
@@ -140,22 +140,22 @@ XPathReactElement.prototype.getName = function () {
   }
 };
 
-XPathReactElement.prototype.getAttributes = function () {
+XPathReactElement.prototype.getAttributes = function() {
   var props;
   var attributes = [];
   var i = 0;
 
   if (ReactInternals.isDOMComponent(this.nativeNode)) {
     var domInternalInstance = ReactInternals.getInternalInstance(this.nativeNode);
-    props = domInternalInstance._currentElement.props;
+    props = domInternalInstance._currentElement && domInternalInstance._currentElement.props;
 
   } else if (ReactInternals.isCompositeComponent(this.nativeNode)) {
     var internalInstance = ReactInternals.getInternalInstance(this.nativeNode);
-    var key = internalInstance && internalInstance._currentElement && internalInstance._currentElement.key;
+    var key = internalInstance._currentElement && internalInstance._currentElement.key;
     if (key) {
       attributes.push(new XPathReactAttribute("key", key, this, i++));
     }
-    props = internalInstance._currentElement.props;
+    props = internalInstance._currentElement && internalInstance._currentElement.props;
 
   } else {
     props = this.nativeNode.props;
@@ -174,7 +174,7 @@ XPathReactElement.prototype.getAttributes = function () {
   return attributes;
 };
 
-XPathReactElement.prototype.getOwnerDocument = function () {
+XPathReactElement.prototype.getOwnerDocument = function() {
   if (this.getParent().getNodeType() === XPathEvaluator.Node.DOCUMENT_NODE) {
     return this.getParent();
   } else {
@@ -183,8 +183,16 @@ XPathReactElement.prototype.getOwnerDocument = function () {
 };
 
 /* eslint-disable no-underscore-dangle */
-XPathReactElement.prototype._getElementById = function (id) {
-  var props = this.nativeNode.props;
+XPathReactElement.prototype._getElementById = function(id) {
+  var props;
+  if (ReactInternals.isDOMComponent(this.nativeNode) || ReactInternals.isCompositeComponent(this.nativeNode)) {
+    var internalInstance = ReactInternals.getInternalInstance(this.nativeNode);
+    props = internalInstance._currentElement && internalInstance._currentElement.props;
+
+  } else {
+    props = this.nativeNode.props;
+  }
+
   if (props && props.id === id) {
     return this;
   } else {
@@ -203,7 +211,7 @@ XPathReactElement.prototype._getElementById = function (id) {
 };
 /* eslint-enable no-underscore-dangle */
 
-XPathReactElement.prototype.toString = function () {
+XPathReactElement.prototype.toString = function() {
   var name = this.getName();
   var props = this.nativeNode.props;
   if (props) {

--- a/lib/types/react_element.js
+++ b/lib/types/react_element.js
@@ -72,7 +72,7 @@ XPathReactElement.prototype.getParent = function() {
 XPathReactElement.prototype.getChildNodes = function() {
   var children = [];
   if (ReactInternals.isDOMComponent(this.getNativeNode())) {
-    var domInternalInstance = ReactInternals.getDOMInternalInstance(this.nativeNode) || this.nativeNode._reactInternalInstance;
+    var domInternalInstance = this.nativeNode._reactInternalInstance || ReactInternals.getDOMInternalInstance(this.nativeNode);
     if (domInternalInstance._renderedChildren) {
       var renderedChildren = domInternalInstance._renderedChildren;
   
@@ -163,7 +163,7 @@ XPathReactElement.prototype.getAttributes = function() {
   var i = 0;
 
   if (ReactInternals.isDOMComponent(this.getNativeNode())) {
-    var domInternalInstance = ReactInternals.getDOMInternalInstance(this.nativeNode) || this.nativeNode._reactInternalInstance;
+    var domInternalInstance = this.nativeNode._reactInternalInstance || ReactInternals.getDOMInternalInstance(this.nativeNode);
     props = domInternalInstance._currentElement && domInternalInstance._currentElement.props;
 
   } else if (ReactInternals.isCompositeComponent(this.nativeNode)) {
@@ -203,7 +203,7 @@ XPathReactElement.prototype.getOwnerDocument = function() {
 XPathReactElement.prototype._getElementById = function(id) {
   var props;
   if (ReactInternals.isDOMComponent(this.getNativeNode())) {
-    var domInternalInstance = ReactInternals.getDOMInternalInstance(this.nativeNode) || this.nativeNode._reactInternalInstance;
+    var domInternalInstance = this.nativeNode._reactInternalInstance || ReactInternals.getDOMInternalInstance(this.nativeNode);
     props = domInternalInstance._currentElement && domInternalInstance._currentElement.props;
 
   } else if (ReactInternals.isCompositeComponent(this.nativeNode)) {

--- a/lib/types/react_element.js
+++ b/lib/types/react_element.js
@@ -6,6 +6,23 @@ var XPathEvaluator = require("xpath-evaluator");
 var XPathReactAttribute = require("./react_attribute");
 var XPathReactText = require("./react_text");
 
+function getChildElementNode(child) {
+  var pubInst = child.getPublicInstance();
+  if (pubInst) {
+    if (ReactInternals.isDOMComponent(pubInst) && !ReactInternals.getDOMInternalInstance(pubInst)) {
+      // workaround for react 0.14 not having link from dom node to react internal instance
+      return {
+        _domNode: pubInst,
+        _reactInternalInstance: child
+      };
+    } else {
+      return pubInst;
+    }
+  } else {
+    return child._currentElement;
+  }
+}
+
 function XPathReactElement(nativeNode, parent, nChild) {
   this.nativeNode = nativeNode;
   this.parent = parent;
@@ -22,9 +39,9 @@ XPathReactElement.prototype.isEqual = function(node) {
 
 XPathReactElement.prototype.getNativeNode = function() {
   if (ReactInternals.isCompositeComponent(this.nativeNode)) {
-    return this.nativeNode._reactInternalInstance && this.nativeNode._reactInternalInstance._currentElement;
+    return this.nativeNode._reactInternalInstance._currentElement;
   } else {
-    return this.nativeNode;
+    return this.nativeNode._domNode || this.nativeNode;
   }
 };
 
@@ -54,8 +71,8 @@ XPathReactElement.prototype.getParent = function() {
 
 XPathReactElement.prototype.getChildNodes = function() {
   var children = [];
-  if (ReactInternals.isDOMComponent(this.nativeNode)) {
-    var domInternalInstance = ReactInternals.getInternalInstance(this.nativeNode);
+  if (ReactInternals.isDOMComponent(this.getNativeNode())) {
+    var domInternalInstance = ReactInternals.getDOMInternalInstance(this.nativeNode) || this.nativeNode._reactInternalInstance;
     if (domInternalInstance._renderedChildren) {
       var renderedChildren = domInternalInstance._renderedChildren;
   
@@ -67,7 +84,7 @@ XPathReactElement.prototype.getChildNodes = function() {
         if (renderedChildren[key]._stringText) {
           children.push(new XPathReactText(renderedChildren[key]._stringText, this, children.length));
         } else {
-          children.push(new XPathReactElement(renderedChildren[key].getPublicInstance() || renderedChildren[key]._currentElement, this, children.length));
+          children.push(new XPathReactElement(getChildElementNode(renderedChildren[key]), this, children.length));
         }
       }
 
@@ -79,9 +96,9 @@ XPathReactElement.prototype.getChildNodes = function() {
     }
 
   } else if (ReactInternals.isCompositeComponent(this.nativeNode)) {
-    var internalInstance = ReactInternals.getInternalInstance(this.nativeNode);
+    var internalInstance = this.nativeNode._reactInternalInstance;
     if (internalInstance._renderedComponent) {
-      children.push(new XPathReactElement(internalInstance._renderedComponent.getPublicInstance()  || internalInstance._renderedComponent._currentElement, this, 0));
+      children.push(new XPathReactElement(getChildElementNode(internalInstance._renderedComponent), this, 0));
     }
 
   } else if (this.nativeNode.props && this.nativeNode.props.children) {
@@ -145,12 +162,12 @@ XPathReactElement.prototype.getAttributes = function() {
   var attributes = [];
   var i = 0;
 
-  if (ReactInternals.isDOMComponent(this.nativeNode)) {
-    var domInternalInstance = ReactInternals.getInternalInstance(this.nativeNode);
+  if (ReactInternals.isDOMComponent(this.getNativeNode())) {
+    var domInternalInstance = ReactInternals.getDOMInternalInstance(this.nativeNode) || this.nativeNode._reactInternalInstance;
     props = domInternalInstance._currentElement && domInternalInstance._currentElement.props;
 
   } else if (ReactInternals.isCompositeComponent(this.nativeNode)) {
-    var internalInstance = ReactInternals.getInternalInstance(this.nativeNode);
+    var internalInstance = this.nativeNode._reactInternalInstance;
     var key = internalInstance._currentElement && internalInstance._currentElement.key;
     if (key) {
       attributes.push(new XPathReactAttribute("key", key, this, i++));
@@ -185,8 +202,12 @@ XPathReactElement.prototype.getOwnerDocument = function() {
 /* eslint-disable no-underscore-dangle */
 XPathReactElement.prototype._getElementById = function(id) {
   var props;
-  if (ReactInternals.isDOMComponent(this.nativeNode) || ReactInternals.isCompositeComponent(this.nativeNode)) {
-    var internalInstance = ReactInternals.getInternalInstance(this.nativeNode);
+  if (ReactInternals.isDOMComponent(this.getNativeNode())) {
+    var internalInstance = ReactInternals.getDOMInternalInstance(this.nativeNode) || this.nativeNode._reactInternalInstance;
+    props = internalInstance._currentElement && internalInstance._currentElement.props;
+
+  } else if (ReactInternals.isCompositeComponent(this.nativeNode)) {
+    var internalInstance = this.nativeNode._reactInternalInstance;
     props = internalInstance._currentElement && internalInstance._currentElement.props;
 
   } else {

--- a/lib/types/react_element.js
+++ b/lib/types/react_element.js
@@ -1,35 +1,40 @@
 "use strict";
 
+var React = require("react");
+var ReactInternals = require("../ReactInternals");
 var XPathEvaluator = require("xpath-evaluator");
 
-var ReactAttribute = require("./react_attribute");
+var XPathReactAttribute = require("./react_attribute");
+var XPathReactText = require("./react_text");
 
-var ReactText = require("./react_text");
 
-function ReactElement (nativeNode, parent, nChild) {
+function XPathReactElement (nativeNode, parent, nChild) {
   this.nativeNode = nativeNode;
   this.parent = parent;
   this.nChild = nChild;
 }
 
-ReactElement.prototype.getId = function () {
+XPathReactElement.prototype.getId = function () {
   return this.getParent().getId() + "." + this.nChild;
 };
 
-ReactElement.prototype.isEqual = function (node) {
+XPathReactElement.prototype.isEqual = function (node) {
   return this.getId() === node.getId();
 };
 
-ReactElement.prototype.getNativeNode = function () {
-  return this.nativeNode;
+XPathReactElement.prototype.getNativeNode = function () {
+  if (ReactInternals.isCompositeComponent(this.nativeNode)) {
+    return this.nativeNode._reactInternalInstance && this.nativeNode._reactInternalInstance._currentElement;
+  } else {
+    return this.nativeNode;
+  }
 };
 
-ReactElement.prototype.asString = function () {
+XPathReactElement.prototype.asString = function () {
   var textContent = "";
 
   this.getChildNodes().forEach(function (child) {
-    if (child.getNodeType() === XPathEvaluator.Node.ELEMENT_NODE ||
-        child.getNodeType() === XPathEvaluator.Node.TEXT_NODE) {
+    if (child.getNodeType() === XPathEvaluator.Node.ELEMENT_NODE || child.getNodeType() === XPathEvaluator.Node.TEXT_NODE) {
       textContent = textContent + child.asString();
     }
   });
@@ -37,52 +42,57 @@ ReactElement.prototype.asString = function () {
   return textContent;
 };
 
-ReactElement.prototype.asNumber = function () {
+XPathReactElement.prototype.asNumber = function () {
   return +this.asString();
 };
 
-ReactElement.prototype.getNodeType = function () {
+XPathReactElement.prototype.getNodeType = function () {
   return XPathEvaluator.Node.ELEMENT_NODE;
 };
 
-ReactElement.prototype.getParent = function () {
+XPathReactElement.prototype.getParent = function () {
   return this.parent;
 };
 
-ReactElement.prototype.getChildNodes = function () {
-  if (!this.nativeNode.props || !this.nativeNode.props.children) {
-    return [];
-  }
+XPathReactElement.prototype.getChildNodes = function () {
+  if (ReactInternals.isDOMComponent(this.nativeNode) || ReactInternals.isCompositeComponent(this.nativeNode)) {
+    var internalInstance = ReactInternals.getInternalInstance(this.nativeNode);
+    if (internalInstance._renderedChildren || internalInstance._renderedComponent) {
+      var renderedChildren = internalInstance._renderedChildren || { "child" : internalInstance._renderedComponent };
+  
+      var children = [];
+      for (var key in renderedChildren) {
+        if (!renderedChildren.hasOwnProperty(key) || !renderedChildren[key]) {
+          continue;
+        }
 
-  var children = [];
-
-  var addChild = function (child, i) {
-    if (child) {
-      if (typeof child === "string") {
-        children.push(new ReactText(child, this, i));
-      } else {
-        children.push(new ReactElement(child, this, i));
+        if (renderedChildren[key]._stringText) {
+          children.push(new XPathReactText(renderedChildren[key]._stringText, this, children.length));
+        } else {
+          children.push(new XPathReactElement(renderedChildren[key].getPublicInstance(), this, children.length));
+        }
       }
     }
-  }.bind(this);
+    return children;
 
-  function flatten (array) {
-    return array.reduce(function(memo, el) {
-      var items = Array.isArray(el) ? flatten(el) : [el];
-      return memo.concat(items);
-    }, []);
-  }
+  } else {
+    if (!this.nativeNode.props || !this.nativeNode.props.children) {
+      return [];
+    }
 
-  var flattenedChildren = flatten([this.nativeNode.props.children]);
-
-  for (var i = 0; i < flattenedChildren.length; i++) {
-    addChild(flattenedChildren[i], i);
-  }
-
-  return children;
+    var children = [];
+    React.Children.forEach(this.nativeNode.props.children, function(child) {
+      if (typeof child === "string") {
+        children.push(new XPathReactText(child, this, children.length));
+      } else {
+        children.push(new XPathReactElement(child, this, children.length));
+      }
+    }.bind(this));
+    return children;
+  }  
 };
 
-ReactElement.prototype.getFollowingSiblings = function () {
+XPathReactElement.prototype.getFollowingSiblings = function () {
   var followingSiblings = [];
 
   var siblings = this.getParent().getChildNodes();
@@ -98,7 +108,7 @@ ReactElement.prototype.getFollowingSiblings = function () {
   return followingSiblings;
 };
 
-ReactElement.prototype.getPrecedingSiblings = function () {
+XPathReactElement.prototype.getPrecedingSiblings = function () {
   var precedingSiblings = [];
 
   var siblings = this.getParent().getChildNodes();
@@ -114,16 +124,20 @@ ReactElement.prototype.getPrecedingSiblings = function () {
   return precedingSiblings;
 };
 
-ReactElement.prototype.getName = function () {
-  if (typeof this.nativeNode.type === "string") {
-    return this.nativeNode.type;
-  } else if (typeof this.nativeNode.type === "function") {
-    return this.nativeNode.type.displayName || this.nativeNode.type.name;
+XPathReactElement.prototype.getName = function () {
+  var el = this.getNativeNode();
+  if (ReactInternals.isDOMComponent(el)) {
+    return el.localName;
+  } else if (typeof el.type === "function") {
+    return el.type.displayName || el.type.name;
+  } else if (typeof el.type === "string") {
+    return el.type;
   }
 };
 
-ReactElement.prototype.getAttributes = function () {
-  if (!this.nativeNode.props) {
+XPathReactElement.prototype.getAttributes = function () {
+  var props = this.nativeNode.props;
+  if (!props) {
     return [];
   }
 
@@ -131,16 +145,24 @@ ReactElement.prototype.getAttributes = function () {
 
   var i = 0;
 
-  for (var attribute in this.nativeNode.props) {
-    if (this.nativeNode.props.hasOwnProperty(attribute) && attribute !== "children") {
-      attributes.push(new ReactAttribute(attribute, this.nativeNode.props[attribute], this, i++));
+  if (ReactInternals.isCompositeComponent(this.nativeNode)) {
+    var internalInstance = this.nativeNode._reactInternalInstance;
+    var key = internalInstance && internalInstance._currentElement && internalInstance._currentElement.key;
+    if (key) {
+      attributes.push(new XPathReactAttribute("key", key, this, i++));
+    }
+  }
+
+  for (var attribute in props) {
+    if (props.hasOwnProperty(attribute) && attribute !== "children") {
+      attributes.push(new XPathReactAttribute(attribute, props[attribute], this, i++));
     }
   }
 
   return attributes;
 };
 
-ReactElement.prototype.getOwnerDocument = function () {
+XPathReactElement.prototype.getOwnerDocument = function () {
   if (this.getParent().getNodeType() === XPathEvaluator.Node.DOCUMENT_NODE) {
     return this.getParent();
   } else {
@@ -149,8 +171,9 @@ ReactElement.prototype.getOwnerDocument = function () {
 };
 
 /* eslint-disable no-underscore-dangle */
-ReactElement.prototype._getElementById = function (id) {
-  if (this.nativeNode.props && this.nativeNode.props.id === id) {
+XPathReactElement.prototype._getElementById = function (id) {
+  var props = this.nativeNode.props;
+  if (props && props.id === id) {
     return this;
   } else {
     var children = this.getChildNodes();
@@ -168,20 +191,20 @@ ReactElement.prototype._getElementById = function (id) {
 };
 /* eslint-enable no-underscore-dangle */
 
-ReactElement.prototype.toString = function () {
+XPathReactElement.prototype.toString = function () {
   var name = this.getName();
-
-  if (this.nativeNode.props) {
-    if (this.nativeNode.props.className) {
-      name = name + "." + this.nativeNode.props.className.split(/\s+/g).join(".");
+  var props = this.nativeNode.props;
+  if (props) {
+    if (props.className) {
+      name = name + "." + props.className.split(/\s+/g).join(".");
     }
 
-    if (this.nativeNode.props.id) {
-      name = name + "#" + this.nativeNode.props.id;
+    if (props.id) {
+      name = name + "#" + props.id;
     }
   }
 
   return "Node<" + name + ">";
 };
 
-module.exports = ReactElement;
+module.exports = XPathReactElement;

--- a/lib/types/react_element.js
+++ b/lib/types/react_element.js
@@ -1,12 +1,10 @@
 "use strict";
 
-var React = require("react");
 var ReactInternals = require("../ReactInternals");
 var XPathEvaluator = require("xpath-evaluator");
 
 var XPathReactAttribute = require("./react_attribute");
 var XPathReactText = require("./react_text");
-
 
 function XPathReactElement (nativeNode, parent, nChild) {
   this.nativeNode = nativeNode;
@@ -74,9 +72,9 @@ XPathReactElement.prototype.getChildNodes = function () {
       }
 
     } else if (domInternalInstance._currentElement.props && domInternalInstance._currentElement.props.children) {
-      React.Children.forEach(domInternalInstance._currentElement.props.children, function(child) {
+      ReactInternals.forEachChild(domInternalInstance._currentElement.props.children, function(child) {
         children.push(new XPathReactText(child, this, children.length));
-      }.bind(this));
+      }, this);
 
     }
 
@@ -87,13 +85,13 @@ XPathReactElement.prototype.getChildNodes = function () {
     }
 
   } else if (this.nativeNode.props && this.nativeNode.props.children) {
-    React.Children.forEach(this.nativeNode.props.children, function(child) {
+    ReactInternals.forEachChild(this.nativeNode.props.children, function(child) {
       if (typeof child === "string") {
         children.push(new XPathReactText(child, this, children.length));
       } else {
         children.push(new XPathReactElement(child, this, children.length));
       }
-    }.bind(this));
+    }, this);
   } 
 
   return children;

--- a/lib/types/react_element.js
+++ b/lib/types/react_element.js
@@ -203,8 +203,8 @@ XPathReactElement.prototype.getOwnerDocument = function() {
 XPathReactElement.prototype._getElementById = function(id) {
   var props;
   if (ReactInternals.isDOMComponent(this.getNativeNode())) {
-    var internalInstance = ReactInternals.getDOMInternalInstance(this.nativeNode) || this.nativeNode._reactInternalInstance;
-    props = internalInstance._currentElement && internalInstance._currentElement.props;
+    var domInternalInstance = ReactInternals.getDOMInternalInstance(this.nativeNode) || this.nativeNode._reactInternalInstance;
+    props = domInternalInstance._currentElement && domInternalInstance._currentElement.props;
 
   } else if (ReactInternals.isCompositeComponent(this.nativeNode)) {
     var internalInstance = this.nativeNode._reactInternalInstance;

--- a/lib/types/react_element.js
+++ b/lib/types/react_element.js
@@ -55,13 +55,13 @@ XPathReactElement.prototype.getParent = function () {
 };
 
 XPathReactElement.prototype.getChildNodes = function () {
-  if (ReactInternals.isDOMComponent(this.nativeNode) || ReactInternals.isCompositeComponent(this.nativeNode)) {
+  if (ReactInternals.isDOMComponent(this.nativeNode)) {
     var internalInstance = ReactInternals.getInternalInstance(this.nativeNode);
-    if (internalInstance._renderedChildren || internalInstance._renderedComponent) {
-      var renderedChildren = internalInstance._renderedChildren || { "child" : internalInstance._renderedComponent };
+    if (internalInstance._renderedChildren) {
+      var renderedChildren = internalInstance._renderedChildren;
   
       var children = [];
-      for (var key in renderedChildren) {
+      for (var key in internalInstance._renderedChildren) {
         if (!renderedChildren.hasOwnProperty(key) || !renderedChildren[key]) {
           continue;
         }
@@ -72,14 +72,28 @@ XPathReactElement.prototype.getChildNodes = function () {
           children.push(new XPathReactElement(renderedChildren[key].getPublicInstance(), this, children.length));
         }
       }
-    }
-    return children;
+      return children;
 
-  } else {
-    if (!this.nativeNode.props || !this.nativeNode.props.children) {
+    } else if (internalInstance._currentElement.props && internalInstance._currentElement.props.children) {
+      var children = [];
+      React.Children.forEach(internalInstance._currentElement.props.children, function(child) {
+        children.push(new XPathReactText(child, this, children.length));
+      }.bind(this));
+      return children;
+
+    } else {
       return [];
     }
 
+  } else if (ReactInternals.isCompositeComponent(this.nativeNode)) {
+    var internalInstance = ReactInternals.getInternalInstance(this.nativeNode);
+    if (internalInstance._renderedComponent) {
+      return [new XPathReactElement(internalInstance._renderedComponent.getPublicInstance(), this, 0)];
+    } else {
+      return [];
+    }
+
+  } else if (this.nativeNode.props && this.nativeNode.props.children) {
     var children = [];
     React.Children.forEach(this.nativeNode.props.children, function(child) {
       if (typeof child === "string") {
@@ -89,7 +103,10 @@ XPathReactElement.prototype.getChildNodes = function () {
       }
     }.bind(this));
     return children;
-  }  
+
+  } else {
+    return [];
+  } 
 };
 
 XPathReactElement.prototype.getFollowingSiblings = function () {
@@ -136,21 +153,27 @@ XPathReactElement.prototype.getName = function () {
 };
 
 XPathReactElement.prototype.getAttributes = function () {
-  var props = this.nativeNode.props;
-  if (!props) {
-    return [];
-  }
-
+  var props;
   var attributes = [];
-
   var i = 0;
 
-  if (ReactInternals.isCompositeComponent(this.nativeNode)) {
-    var internalInstance = this.nativeNode._reactInternalInstance;
+  if (ReactInternals.isDOMComponent(this.nativeNode)) {
+    var internalInstance = ReactInternals.getInternalInstance(this.nativeNode);
+    props = internalInstance._currentElement.props;
+
+  } else if (ReactInternals.isCompositeComponent(this.nativeNode)) {
+    var internalInstance = ReactInternals.getInternalInstance(this.nativeNode);
     var key = internalInstance && internalInstance._currentElement && internalInstance._currentElement.key;
     if (key) {
       attributes.push(new XPathReactAttribute("key", key, this, i++));
     }
+
+  } else {
+    props = this.nativeNode.props;
+  }
+
+  if (!props) {
+    return [];
   }
 
   for (var attribute in props) {

--- a/lib/types/react_text.js
+++ b/lib/types/react_text.js
@@ -2,45 +2,45 @@
 
 var XPathEvaluator = require("xpath-evaluator");
 
-function ReactText (textContent, parent, nChild) {
+function XPathReactText (textContent, parent, nChild) {
   this.textContent = textContent;
   this.parent = parent;
   this.nChild = nChild;
 }
 
-ReactText.prototype.getId = function () {
+XPathReactText.prototype.getId = function () {
   return this.getParent().getId() + "." + this.nChild;
 };
 
-ReactText.prototype.isEqual = function (node) {
+XPathReactText.prototype.isEqual = function (node) {
   return this.getId() === node.getId();
 };
 
-ReactText.prototype.getNativeNode = function () {
+XPathReactText.prototype.getNativeNode = function () {
   return this.textContent;
 };
 
-ReactText.prototype.asString = function () {
+XPathReactText.prototype.asString = function () {
   return this.textContent;
 };
 
-ReactText.prototype.asNumber = function () {
+XPathReactText.prototype.asNumber = function () {
   return +this.asString();
 };
 
-ReactText.prototype.getNodeType = function () {
+XPathReactText.prototype.getNodeType = function () {
   return XPathEvaluator.Node.TEXT_NODE;
 };
 
-ReactText.prototype.getParent = function () {
+XPathReactText.prototype.getParent = function () {
   return this.parent;
 };
 
-ReactText.prototype.getChildNodes = function () {
+XPathReactText.prototype.getChildNodes = function () {
   return undefined;
 };
 
-ReactText.prototype.getFollowingSiblings = function () {
+XPathReactText.prototype.getFollowingSiblings = function () {
   var followingSiblings = [];
 
   var siblings = this.getParent().getChildNodes();
@@ -56,7 +56,7 @@ ReactText.prototype.getFollowingSiblings = function () {
   return followingSiblings;
 };
 
-ReactText.prototype.getPrecedingSiblings = function () {
+XPathReactText.prototype.getPrecedingSiblings = function () {
   var precedingSiblings = [];
 
   var siblings = this.getParent().getChildNodes();
@@ -72,20 +72,20 @@ ReactText.prototype.getPrecedingSiblings = function () {
   return precedingSiblings;
 };
 
-ReactText.prototype.getName = function () {
+XPathReactText.prototype.getName = function () {
   return undefined;
 };
 
-ReactText.prototype.getAttributes = function () {
+XPathReactText.prototype.getAttributes = function () {
   return undefined;
 };
 
-ReactText.prototype.getOwnerDocument = function () {
+XPathReactText.prototype.getOwnerDocument = function () {
   return this.getParent().getOwnerDocument();
 };
 
-ReactText.prototype.toString = function () {
+XPathReactText.prototype.toString = function () {
   return "Node<text(" + this.textContent + ")>";
 };
 
-module.exports = ReactText;
+module.exports = XPathReactText;

--- a/lib/types/react_text.js
+++ b/lib/types/react_text.js
@@ -2,50 +2,50 @@
 
 var XPathEvaluator = require("xpath-evaluator");
 
-function XPathReactText (textContent, parent, nChild) {
+function XPathReactText(textContent, parent, nChild) {
   this.textContent = textContent;
   this.parent = parent;
   this.nChild = nChild;
 }
 
-XPathReactText.prototype.getId = function () {
+XPathReactText.prototype.getId = function() {
   return this.getParent().getId() + "." + this.nChild;
 };
 
-XPathReactText.prototype.isEqual = function (node) {
+XPathReactText.prototype.isEqual = function(node) {
   return this.getId() === node.getId();
 };
 
-XPathReactText.prototype.getNativeNode = function () {
+XPathReactText.prototype.getNativeNode = function() {
   return this.textContent;
 };
 
-XPathReactText.prototype.asString = function () {
+XPathReactText.prototype.asString = function() {
   return this.textContent;
 };
 
-XPathReactText.prototype.asNumber = function () {
+XPathReactText.prototype.asNumber = function() {
   return +this.asString();
 };
 
-XPathReactText.prototype.getNodeType = function () {
+XPathReactText.prototype.getNodeType = function() {
   return XPathEvaluator.Node.TEXT_NODE;
 };
 
-XPathReactText.prototype.getParent = function () {
+XPathReactText.prototype.getParent = function() {
   return this.parent;
 };
 
-XPathReactText.prototype.getChildNodes = function () {
+XPathReactText.prototype.getChildNodes = function() {
   return undefined;
 };
 
-XPathReactText.prototype.getFollowingSiblings = function () {
+XPathReactText.prototype.getFollowingSiblings = function() {
   var followingSiblings = [];
 
   var siblings = this.getParent().getChildNodes();
 
-  var thisSiblingIndex = siblings.findIndex(function (sibling) {
+  var thisSiblingIndex = siblings.findIndex(function(sibling) {
     return sibling.getNativeNode() === this.getNativeNode();
   }.bind(this));
 
@@ -56,12 +56,12 @@ XPathReactText.prototype.getFollowingSiblings = function () {
   return followingSiblings;
 };
 
-XPathReactText.prototype.getPrecedingSiblings = function () {
+XPathReactText.prototype.getPrecedingSiblings = function() {
   var precedingSiblings = [];
 
   var siblings = this.getParent().getChildNodes();
 
-  var thisSiblingIndex = siblings.findIndex(function (sibling) {
+  var thisSiblingIndex = siblings.findIndex(function(sibling) {
     return sibling.getNativeNode() === this.getNativeNode();
   }.bind(this));
 
@@ -72,19 +72,19 @@ XPathReactText.prototype.getPrecedingSiblings = function () {
   return precedingSiblings;
 };
 
-XPathReactText.prototype.getName = function () {
+XPathReactText.prototype.getName = function() {
   return undefined;
 };
 
-XPathReactText.prototype.getAttributes = function () {
+XPathReactText.prototype.getAttributes = function() {
   return undefined;
 };
 
-XPathReactText.prototype.getOwnerDocument = function () {
+XPathReactText.prototype.getOwnerDocument = function() {
   return this.getParent().getOwnerDocument();
 };
 
-XPathReactText.prototype.toString = function () {
+XPathReactText.prototype.toString = function() {
   return "Node<text(" + this.textContent + ")>";
 };
 

--- a/package.json
+++ b/package.json
@@ -19,10 +19,7 @@
     "eslint-plugin-react": "3.8.0",
     "istanbul": "0.3.22",
     "jsdom": "9.8.3",
-    "mocha": "2.3.0",
-    "react": "15.4.1",
-    "react-dom": "15.4.1",
-    "react-addons-test-utils": "15.4.1"
+    "mocha": "2.3.0"
   },
   "files": [
     "index.js",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "eslint": "1.9.0",
     "eslint-plugin-react": "3.8.0",
     "istanbul": "0.3.22",
+    "jsdom": "9.8.3",
     "mocha": "2.3.0",
     "react": "15.4.1",
     "react-dom": "15.4.1",
@@ -29,7 +30,8 @@
     "lib"
   ],
   "scripts": {
-    "test": "mocha ./test/**/*_test.js --ui tdd --compilers js:babel/register --reporter spec"
+    "test": "mocha --reporter dot --ui tdd --compilers js:babel/register test/**/*_test.js",
+    "test-cover": "istanbul cover --report lcov node_modules/mocha/bin/_mocha -- --reporter dot --ui tdd --compilers js:babel/register test/**/*_test.js"
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "xpath-react",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "A React adapter for xpath-evaluator.",
-  "main": "lib/types/react_document.js",
+  "main": "index.js",
   "author": "Jonas Amundsen <jonasba@gmail.com>",
   "repository": {
     "type": "git",
@@ -10,7 +10,6 @@
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0",
-    "react-addons-test-utils": "^0.14.0 || ^15.0.0",
     "xpath-evaluator": "^2.0.0"
   },
   "devDependencies": {
@@ -19,12 +18,18 @@
     "eslint": "1.9.0",
     "eslint-plugin-react": "3.8.0",
     "istanbul": "0.3.22",
-    "mocha": "2.3.0"
+    "mocha": "2.3.0",
+    "react": "15.4.1",
+    "react-dom": "15.4.1",
+    "react-addons-test-utils": "15.4.1"
   },
   "files": [
-    "register.js",
+    "index.js",
     "utils.js",
     "lib"
   ],
+  "scripts": {
+    "test": "mocha ./test/**/*_test.js --ui tdd --compilers js:babel/register --reporter spec"
+  },
   "license": "MIT"
 }

--- a/register.js
+++ b/register.js
@@ -1,7 +1,0 @@
-var XPathEvaluator = require("xpath-evaluator");
-
-var ReactDocument = require("./lib/types/react_document");
-
-XPathEvaluator.setAdapter(ReactDocument);
-
-module.exports = XPathEvaluator;

--- a/test/ancestor_test.js
+++ b/test/ancestor_test.js
@@ -4,16 +4,22 @@ var React = require("react");
 
 var Helper = require("./helper");
 
-var document = (
-  <html>
-    <head>
-      <title>title</title>
-    </head>
-    <body>
-      <h1 id='t'>foo</h1>
-    </body>
-  </html>
-);
+var Doc = React.createClass({
+  render: function () {
+    return (
+      <html>
+        <head>
+          <title>title</title>
+        </head>
+        <body>
+          <h1 id='t'>foo</h1>
+        </body>
+      </html>
+    );
+  }
+});
+
+var document = Helper.render(<Doc/>);
 
 var assertEvaluatesToNodeSet = Helper.assertEvaluatesToNodeSet.bind(null, document);
 

--- a/test/attribute_test.js
+++ b/test/attribute_test.js
@@ -4,33 +4,39 @@ var React = require("react");
 
 var Helper = require("./helper");
 
-var document = (
-  <html>
-    <head>
-      <title>Title</title>
-      <link rel='index' href='http://coderepos.org/' type='text/html' />
-    </head>
-    <body>
-      <blockquote
-          title='CodeRepos'
-          cite='http://coderepos.org/'>
-        <p title='paragraph' id='paragraph'>
-          <br id='pSib' />
-          <input name='foo' id='bar' className='input-1' />
-          <input name='bar' id='foo' className='input-2' />
-          <img name='hoge' id='fuga' className='img-1' />
-          <img name='fuga' id='hoge' className='img-2' />
-          <br id='nSib' />
-          Share your codes!
-          <input htmlFor='foo' />
-        </p>
-        <cite className='cite site'>
-          <a title='CodeRepos' href='http://coderepos.org/'>CodeRepos</a>
-        </cite>
-      </blockquote>
-    </body>
-  </html>
-);
+var Doc = React.createClass({
+  render: function () {
+    return (
+      <html>
+        <head>
+          <title>Title</title>
+          <link rel='index' href='http://coderepos.org/' type='text/html' />
+        </head>
+        <body>
+          <blockquote
+              title='CodeRepos'
+              cite='http://coderepos.org/'>
+            <p title='paragraph' id='paragraph'>
+              <br id='pSib' />
+              <input name='foo' id='bar' className='input-1' />
+              <input name='bar' id='foo' className='input-2' />
+              <img name='hoge' id='fuga' className='img-1' />
+              <img name='fuga' id='hoge' className='img-2' />
+              <br id='nSib' />
+              Share your codes!
+              <input htmlFor='foo' />
+            </p>
+            <cite className='cite site'>
+              <a title='CodeRepos' href='http://coderepos.org/'>CodeRepos</a>
+            </cite>
+          </blockquote>
+        </body>
+      </html>
+    );
+  }
+});
+
+var document = Helper.render(<Doc/>);
 
 var assertEvaluatesToNodeSet = Helper.assertEvaluatesToNodeSet.bind(null, document);
 

--- a/test/basic_functional_test.js
+++ b/test/basic_functional_test.js
@@ -4,46 +4,52 @@ var React = require("react");
 
 var Helper = require("./helper");
 
-var document = (
-  <div id='n1' title='1' className='26'>
-    <dl id='n2' title='2' className='3'>
-      <dt id='n3' title='3' className='1'>dt</dt>
-      <dd id='n4' title='4' className='2'>dd</dd>
-    </dl>
-    <center id='n5' title='5' className='22'>
-      <h1 id='n6' title='6' className='6'>
-        <em id='n7' title='7' className='4'>em</em>
-        <strong id='n8' title='8' className='5'>strong</strong>
-      </h1>
-      <h2 id='n9' title='9' className='9'>
-        <b id='n10' title='10' className='7'>b</b>
-        <s id='n11' title='11' className='8'>s</s>
-      </h2>
-      <blockquote id='n12' title='12' className='15'>
-        blockquoteText1:
-        <br id='n13' title='13' className='10'/>
-        blockquoteText2
-        <p id='n14' title='14' className='13'>
-          <del id='n15' title='15' className='11'>del</del>
-          <ins id='n16' title='16' className='12'>ins</ins>
-        </p>
-        <font id='n17' title='17' className='14' face='n8 n26'>font</font>
-      </blockquote>
-      <h3 id='n18' title='18' className='18'>
-        <dfn id='n19' title='19' className='16'>dfn</dfn>
-        <a id='n20' title='20' className='17'>a</a>
-      </h3>
-      <h4 id='n21' title='21' className='21'>
-        <sub id='n22' title='22' className='19'>sub</sub>
-        <sup id='n23' title='23' className='20'>sup</sup>
-      </h4>
-    </center>
-    <span id='n24' title='24' className='25'>
-      <acronym id='n25' title='25' className='23'>acronym</acronym>
-      <q id='n26' title='26' className='24' cite='n8 n17'>q</q>
-    </span>
-  </div>
-);
+var Doc = React.createClass({
+  render: function () {
+    return (
+      <div id='n1' title='1' className='26'>
+        <dl id='n2' title='2' className='3'>
+          <dt id='n3' title='3' className='1'>dt</dt>
+          <dd id='n4' title='4' className='2'>dd</dd>
+        </dl>
+        <center id='n5' title='5' className='22'>
+          <h1 id='n6' title='6' className='6'>
+            <em id='n7' title='7' className='4'>em</em>
+            <strong id='n8' title='8' className='5'>strong</strong>
+          </h1>
+          <h2 id='n9' title='9' className='9'>
+            <b id='n10' title='10' className='7'>b</b>
+            <s id='n11' title='11' className='8'>s</s>
+          </h2>
+          <blockquote id='n12' title='12' className='15'>
+            blockquoteText1:
+            <br id='n13' title='13' className='10'/>
+            blockquoteText2
+            <p id='n14' title='14' className='13'>
+              <del id='n15' title='15' className='11'>del</del>
+              <ins id='n16' title='16' className='12'>ins</ins>
+            </p>
+            <font id='n17' title='17' className='14' face='n8 n26'>font</font>
+          </blockquote>
+          <h3 id='n18' title='18' className='18'>
+            <dfn id='n19' title='19' className='16'>dfn</dfn>
+            <a id='n20' title='20' className='17'>a</a>
+          </h3>
+          <h4 id='n21' title='21' className='21'>
+            <sub id='n22' title='22' className='19'>sub</sub>
+            <sup id='n23' title='23' className='20'>sup</sup>
+          </h4>
+        </center>
+        <span id='n24' title='24' className='25'>
+          <acronym id='n25' title='25' className='23'>acronym</acronym>
+          <q id='n26' title='26' className='24' cite='n8 n17'>q</q>
+        </span>
+      </div>
+    );
+  }
+});
+
+var document = Helper.render(<Doc/>);
 
 var assertEvaluatesToNodeSet = Helper.assertEvaluatesToNodeSet.bind(null, document);
 

--- a/test/child_component_test.js
+++ b/test/child_component_test.js
@@ -2,9 +2,9 @@
 
 var Assert = require("assert");
 
-var XPathEvaluator = require("../register");
+var XPathEvaluator = require("../index");
 
-var XPathUtils = require("../utils");
+var Helper = require("./helper");
 
 var React = require("react");
 
@@ -31,7 +31,7 @@ var Bar = React.createClass({
 suite("XPathReact", function () {
   suite("child component", function () {
     test("unrendered child component", function () {
-      var document = XPathUtils.render(<Bar />);
+      var document = Helper.render(<Bar />);
 
       var expression = ".//Foo";
 
@@ -41,7 +41,7 @@ suite("XPathReact", function () {
     });
 
     test("unrendered child component (complex)", function () {
-      var document = XPathUtils.render(<Bar />);
+      var document = Helper.render(<Bar />);
 
       var expression = "string(.//Foo/parent::*)";
 
@@ -59,7 +59,7 @@ suite("XPathReact", function () {
         return <p><Qux /></p>;
       }
 
-      var document = XPathUtils.render(<Norf />);
+      var document = Helper.render(<Norf />);
 
       var expression = ".//Qux";
 
@@ -80,7 +80,7 @@ suite("XPathReact", function () {
         );
       }
 
-      var document = XPathUtils.render(<Qux />);
+      var document = Helper.render(<Qux />);
 
       var expression = "count(//p)";
 

--- a/test/complex_hrex_test.js
+++ b/test/complex_hrex_test.js
@@ -5,18 +5,24 @@ var React = require("react");
 var Helper = require("./helper");
 
 /* eslint-disable no-script-url */
-var document = (
-  <html>
-    <body>
-      <a id='id0-0' href='javascript:doFoo(a, b)'>foo</a>
-      <a id='id0-1' href='javascript:doFoo(a, %20b)'>foo</a>
-      <a id='id0-2' href='javascript:doFoo(%61, %20b)'>foo</a>
-      <a id='id1-0' href='http://example.com/a b'>foo</a>
-      <a id='id1-1' href='http://example.com/a%20b'>foo</a>
-      <a id='id1-2' href='http://example.com/%61%20b'>foo</a>
-    </body>
-  </html>
-);
+var Doc = React.createClass({
+  render: function () {
+    return (
+      <html>
+        <body>
+          <a id='id0-0' href='javascript:doFoo(a, b)'>foo</a>
+          <a id='id0-1' href='javascript:doFoo(a, %20b)'>foo</a>
+          <a id='id0-2' href='javascript:doFoo(%61, %20b)'>foo</a>
+          <a id='id1-0' href='http://example.com/a b'>foo</a>
+          <a id='id1-1' href='http://example.com/a%20b'>foo</a>
+          <a id='id1-2' href='http://example.com/%61%20b'>foo</a>
+        </body>
+      </html>
+    );
+  }
+});
+
+var document = Helper.render(<Doc/>);
 /* eslint-ena enable no-script-url */
 
 var assertEvaluatesToNodeSet = Helper.assertEvaluatesToNodeSet.bind(null, document);

--- a/test/descendant_test.js
+++ b/test/descendant_test.js
@@ -4,16 +4,22 @@ var React = require("react");
 
 var Helper = require("./helper");
 
-var document = (
-  <html>
-    <head>
-      <title>title</title>
-    </head>
-    <body>
-      <h1>foo</h1>
-    </body>
-  </html>
-);
+var Doc = React.createClass({
+  render: function () {
+    return (
+      <html>
+        <head>
+          <title>title</title>
+        </head>
+        <body>
+          <h1>foo</h1>
+        </body>
+      </html>
+    );
+  }
+});
+
+var document = Helper.render(<Doc/>);
 
 var assertEvaluatesToNodeSet = Helper.assertEvaluatesToNodeSet.bind(null, document);
 

--- a/test/dom_ancestor_test.js
+++ b/test/dom_ancestor_test.js
@@ -1,0 +1,98 @@
+"use strict";
+
+var React = require("react");
+var ReactDom = require("react-dom");
+
+var Helper = require("./helper");
+
+var jsdom = require("jsdom");
+
+global.document = jsdom.jsdom("");
+global.window = document.defaultView;
+global.navigator = window.navigator;
+
+var Doc = React.createClass({
+  render: function () {
+    return (
+      <section>
+        <div>
+          <h1 id='t'>foo</h1>
+        </div>
+      </section>
+    );
+  }
+});
+
+var div = document.createElement("div");
+document.body.appendChild(div);
+var output = ReactDom.render(<Doc />, div);
+
+var assertEvaluatesToNodeSet = Helper.assertEvaluatesToNodeSet.bind(null, output);
+
+suite("XPathReact", function () {
+  suite("ancestor", function () {
+    test("00", function () {
+      assertEvaluatesToNodeSet("id('t')/ancestor::*", ["Doc", "section", "div"]);
+    });
+
+    test.skip("01", function () {
+      assertEvaluatesToNodeSet("id('t')/ancestor::node()", ["document()", "Doc", "section", "div"]);
+    });
+
+    test("02", function () {
+      assertEvaluatesToNodeSet("id('t')/ancestor-or-self::*", ["Doc", "section", "div", "h1"]);
+    });
+
+    test.skip("03", function () {
+      assertEvaluatesToNodeSet("id('t')/ancestor-or-self::node()", ["document()", "Doc", "section", "div", "h1"]);
+    });
+
+    test("04", function () {
+      assertEvaluatesToNodeSet("id('t')/ancestor-or-self::node()/ancestor::*", ["Doc", "section", "div"]);
+    });
+
+    test.skip("05", function () {
+      assertEvaluatesToNodeSet("id('t')/ancestor-or-self::node()/ancestor::node()", ["document()", "Doc", "section", "div"]);
+    });
+
+    test("06", function () {
+      assertEvaluatesToNodeSet("id('t')/ancestor-or-self::node()/ancestor-or-self::*", ["Doc", "section", "div", "h1"]);
+    });
+
+    test.skip("07", function () {
+      assertEvaluatesToNodeSet("id('t')/ancestor-or-self::node()/ancestor-or-self::node()", ["document()", "Doc", "section", "div", "h1"]);
+    });
+
+    test("08", function () {
+      assertEvaluatesToNodeSet("id('t')/ancestor::*[1]", ["div"]);
+    });
+
+    test("09", function () {
+      assertEvaluatesToNodeSet("id('t')/ancestor::node()[1]", ["div"]);
+    });
+
+    test("10", function () {
+      assertEvaluatesToNodeSet("id('t')/ancestor-or-self::*[1]", ["h1"]);
+    });
+
+    test("11", function () {
+      assertEvaluatesToNodeSet("id('t')/ancestor-or-self::node()[1]", ["h1"]);
+    });
+
+    test("12", function () {
+      assertEvaluatesToNodeSet("id('t')/ancestor-or-self::node()/ancestor::*[1]", ["Doc", "section", "div"]);
+    });
+
+    test.skip("13", function () {
+      assertEvaluatesToNodeSet("id('t')/ancestor-or-self::node()/ancestor::node()[1]", ["document()", "Doc", "section", "div"]);
+    });
+
+    test("14", function () {
+      assertEvaluatesToNodeSet("id('t')/ancestor-or-self::node()/ancestor-or-self::*[1]", ["Doc", "section", "div", "h1"]);
+    });
+
+    test.skip("15", function () {
+      assertEvaluatesToNodeSet("id('t')/ancestor-or-self::node()/ancestor-or-self::node()[1]", ["document()", "Doc", "section", "div", "h1"]);
+    });
+  });
+});

--- a/test/dom_attribute_test.js
+++ b/test/dom_attribute_test.js
@@ -1,0 +1,334 @@
+"use strict";
+
+var React = require("react");
+var ReactDom = require("react-dom");
+
+var Helper = require("./helper");
+
+var jsdom = require("jsdom");
+
+global.document = jsdom.jsdom("");
+global.window = document.defaultView;
+global.navigator = window.navigator;
+
+var Doc = React.createClass({
+  render: function () {
+    return (
+      <div>
+        <blockquote
+            title='CodeRepos'
+            cite='http://coderepos.org/'>
+          <p title='paragraph' id='paragraph'>
+            <br id='pSib' />
+            <input name='foo' id='bar' className='input-1' />
+            <input name='bar' id='foo' className='input-2' />
+            <img name='hoge' id='fuga' className='img-1' />
+            <img name='fuga' id='hoge' className='img-2' />
+            <br id='nSib' />
+            Share your codes!
+            <input htmlFor='foo' />
+          </p>
+          <cite className='cite site'>
+            <a title='CodeRepos' href='http://coderepos.org/'>CodeRepos</a>
+          </cite>
+        </blockquote>
+      </div>
+    );
+  }
+});
+
+var div = document.createElement("div");
+document.body.appendChild(div);
+var output = ReactDom.render(<Doc />, div);
+
+var assertEvaluatesToNodeSet = Helper.assertEvaluatesToNodeSet.bind(null, output);
+
+var assertEvaluatesToValue = Helper.assertEvaluatesToValue.bind(null, output);
+
+suite("XPathReact", function () {
+  suite("attribute", function () {
+    test("00", function () {
+      assertEvaluatesToNodeSet("//blockquote['http://coderepos.org/'=@cite]", ["blockquote"]);
+    });
+
+    test("01", function () {
+      assertEvaluatesToNodeSet("/descendant::*['CodeRepos'=@title]", ["blockquote", "a"]);
+    });
+
+    test("02", function () {
+      assertEvaluatesToNodeSet("//*[@class]", ["input", "input", "img", "img", "cite"]);
+    });
+
+    test("03", function () {
+      assertEvaluatesToNodeSet("/descendant::node()[@title]", ["blockquote", "p", "a"]);
+    });
+
+    test("04", function () {
+      assertEvaluatesToNodeSet("//div/*[@title]", ["blockquote"]);
+    });
+
+    test("05", function () {
+      assertEvaluatesToNodeSet("//blockquote/node()[@title]", ["p"]);
+    });
+
+    test("06", function () {
+      assertEvaluatesToNodeSet("//cite[@class='cite']", []);
+    });
+
+    test("07", function () {
+      assertEvaluatesToNodeSet("//cite[@class='site']", []);
+    });
+
+    test("08", function () {
+      assertEvaluatesToNodeSet("//cite[@class='cite site']", ["cite"]);
+    });
+
+    test("09", function () {
+      assertEvaluatesToNodeSet("//*[@id='paragraph']", ["p"]);
+    });
+
+    test("10", function () {
+      assertEvaluatesToNodeSet("//div//*[@id='paragraph']", ["p"]);
+    });
+
+    test("11", function () {
+      assertEvaluatesToNodeSet("//*[@id='bar']", ["input.input-1"]);
+    });
+
+    test("12", function () {
+      assertEvaluatesToNodeSet("//*[@name='foo']", ["input.input-1"]);
+    });
+
+    test("13", function () {
+      assertEvaluatesToNodeSet("//*[@id='foo']", ["input.input-2"]);
+    });
+
+    test("14", function () {
+      assertEvaluatesToNodeSet("//*[@name='bar']", ["input.input-2"]);
+    });
+
+    test("15", function () {
+      assertEvaluatesToNodeSet("//p/node()[@id='bar']", ["input.input-1"]);
+    });
+
+    test("16", function () {
+      assertEvaluatesToNodeSet("//p/node()[@name='foo']", ["input.input-1"]);
+    });
+
+    test("17", function () {
+      assertEvaluatesToNodeSet("//p/node()[@id='foo']", ["input.input-2"]);
+    });
+
+    test("18", function () {
+      assertEvaluatesToNodeSet("//p/node()[@name='bar']", ["input.input-2"]);
+    });
+
+    test("19", function () {
+      assertEvaluatesToNodeSet("id('pSib')/following-sibling::*[@id][1]", ["input.input-1"]);
+    });
+
+    test("20", function () {
+      assertEvaluatesToNodeSet("id('nSib')/preceding-sibling::*[@id][1]", ["img.img-2"]);
+    });
+
+    test("21", function () {
+      assertEvaluatesToNodeSet("id('pSib')/following-sibling::*[@id='foo']", ["input.input-2"]);
+    });
+
+    test("22", function () {
+      assertEvaluatesToNodeSet("id('nSib')/preceding-sibling::*[@id='foo']", ["input.input-2"]);
+    });
+
+    test("23", function () {
+      assertEvaluatesToNodeSet("id('pSib')/following::*[@id='foo']", ["input.input-2"]);
+    });
+
+    test("24", function () {
+      assertEvaluatesToNodeSet("id('nSib')/preceding::*[@id='foo']", ["input.input-2"]);
+    });
+
+    test("25", function () {
+      assertEvaluatesToNodeSet("/descendant::*[@id='foo']", ["input.input-2"]);
+    });
+
+    test("26", function () {
+      assertEvaluatesToNodeSet("/descendant-or-self::*[@id='foo']", ["input.input-2"]);
+    });
+
+    test("27", function () {
+      assertEvaluatesToNodeSet("id('hoge')/self::*[@id='hoge']", ["img.img-2"]);
+    });
+
+    test("28", function () {
+      assertEvaluatesToNodeSet("id('foo')/self::*[@id='foo']", ["input.input-2"]);
+    });
+
+    test("29", function () {
+      assertEvaluatesToNodeSet("id('foo')/parent::*[@id='paragraph']", ["p"]);
+    });
+
+    test("30", function () {
+      assertEvaluatesToNodeSet("id('foo')/ancestor::*[@id='paragraph']", ["p"]);
+    });
+
+    test("31", function () {
+      assertEvaluatesToNodeSet("id('foo')/ancestor-or-self::*[@id='paragraph']", ["p"]);
+    });
+
+    test("32", function () {
+      assertEvaluatesToNodeSet("//*[./@title='CodeRepos']", ["blockquote", "a"]);
+    });
+
+    test("33", function () {
+      assertEvaluatesToNodeSet("//node()[./@class]", ["input", "input", "img", "img", "cite"]);
+    });
+
+    test("34", function () {
+      assertEvaluatesToNodeSet("/descendant::node()[./@title]", ["blockquote", "p", "a"]);
+    });
+
+    test("35", function () {
+      assertEvaluatesToNodeSet("/descendant::blockquote/*[./@title]", ["p"]);
+    });
+
+    test("36", function () {
+      assertEvaluatesToNodeSet("//blockquote[@*='http://coderepos.org/']", ["blockquote"]);
+    });
+
+    test("37", function () {
+      assertEvaluatesToNodeSet("//node()[@*='http://coderepos.org/']", ["blockquote", "a"]);
+    });
+
+    test("38", function () {
+      assertEvaluatesToNodeSet("//*[./@*='http://coderepos.org/']", ["blockquote", "a"]);
+    });
+
+    test("39", function () {
+      assertEvaluatesToNodeSet("//*[(@href|@cite)='http://coderepos.org/']", ["blockquote", "a"]);
+    });
+
+    test("40", function () {
+      assertEvaluatesToValue("count(//blockquote/@*) = count(//blockquote/@* | //blockquote/@*)", true);
+    });
+
+    test("41", function () {
+      assertEvaluatesToNodeSet("//cite[./@class='cite']", []);
+    });
+
+    test("42", function () {
+      assertEvaluatesToNodeSet("//cite[./@class='site']", []);
+    });
+
+    test("43", function () {
+      assertEvaluatesToNodeSet("//cite[./@class='cite site']", ["cite"]);
+    });
+
+    test("44", function () {
+      assertEvaluatesToNodeSet("//*[./@id='paragraph']", ["p"]);
+    });
+
+    test("45", function () {
+      assertEvaluatesToNodeSet("//blockquote//*[./@id='paragraph']", ["p"]);
+    });
+
+    test("46", function () {
+      assertEvaluatesToNodeSet("//*[./@id='bar']", ["input.input-1"]);
+    });
+
+    test("47", function () {
+      assertEvaluatesToNodeSet("//*[./@name='foo']", ["input.input-1"]);
+    });
+
+    test("48", function () {
+      assertEvaluatesToNodeSet("//*[./@id='foo']", ["input.input-2"]);
+    });
+
+    test("49", function () {
+      assertEvaluatesToNodeSet("//*[./@name='bar']", ["input.input-2"]);
+    });
+
+    test("50", function () {
+      assertEvaluatesToNodeSet("//p/node()[./@id='bar']", ["input.input-1"]);
+    });
+
+    test("51", function () {
+      assertEvaluatesToNodeSet("//p/node()[./@name='foo']", ["input.input-1"]);
+    });
+
+    test("52", function () {
+      assertEvaluatesToNodeSet("//p/node()[./@id='foo']", ["input.input-2"]);
+    });
+
+    test("53", function () {
+      assertEvaluatesToNodeSet("//p/node()[./@name='bar']", ["input.input-2"]);
+    });
+
+    test("54", function () {
+      assertEvaluatesToNodeSet("//node()[./@id='bar']", ["input.input-1"]);
+    });
+
+    test("55", function () {
+      assertEvaluatesToNodeSet("//node()[./@name='foo']", ["input.input-1"]);
+    });
+
+    test("56", function () {
+      assertEvaluatesToNodeSet("//node()[./@id='foo']", ["input.input-2"]);
+    });
+
+    test("57", function () {
+      assertEvaluatesToNodeSet("//node()[./@name='bar']", ["input.input-2"]);
+    });
+
+    test("58", function () {
+      assertEvaluatesToNodeSet("id('pSib')/following-sibling::*[./@id][1]", ["input.input-1"]);
+    });
+
+    test("59", function () {
+      assertEvaluatesToNodeSet("id('nSib')/preceding-sibling::*[./@id][1]", ["img.img-2"]);
+    });
+
+    test("60", function () {
+      assertEvaluatesToNodeSet("id('pSib')/following-sibling::*[./@id='foo']", ["input.input-2"]);
+    });
+
+    test("61", function () {
+      assertEvaluatesToNodeSet("id('nSib')/preceding-sibling::*[./@id='foo']", ["input.input-2"]);
+    });
+
+    test("62", function () {
+      assertEvaluatesToNodeSet("id('pSib')/following::*[./@id='foo']", ["input.input-2"]);
+    });
+
+    test("63", function () {
+      assertEvaluatesToNodeSet("id('nSib')/preceding::*[./@id='foo']", ["input.input-2"]);
+    });
+
+    test("64", function () {
+      assertEvaluatesToNodeSet("/descendant::*[./@id='foo']", ["input.input-2"]);
+    });
+
+    test("65", function () {
+      assertEvaluatesToNodeSet("/descendant-or-self::*[./@id='foo']", ["input.input-2"]);
+    });
+
+    test("66", function () {
+      assertEvaluatesToNodeSet("id('foo')/self::*[./@id='foo']", ["input.input-2"]);
+    });
+
+    test("67", function () {
+      assertEvaluatesToNodeSet("id('foo')/parent::*[./@id='paragraph']", ["p"]);
+    });
+
+    test("68", function () {
+      assertEvaluatesToNodeSet("id('foo')/ancestor::*[./@id='paragraph']", ["p"]);
+    });
+
+    test("69", function () {
+      assertEvaluatesToNodeSet("id('foo')/ancestor-or-self::*[./@id='paragraph']", ["p"]);
+    });
+
+    test("70", function () {
+      assertEvaluatesToNodeSet("/descendant::node()[@for]", ["input"]);
+    });
+  });
+});

--- a/test/dom_basic_functional_test.js
+++ b/test/dom_basic_functional_test.js
@@ -1,0 +1,379 @@
+"use strict";
+
+var React = require("react");
+var ReactDom = require("react-dom");
+
+var Helper = require("./helper");
+
+var jsdom = require("jsdom");
+
+global.document = jsdom.jsdom("");
+global.window = document.defaultView;
+global.navigator = window.navigator;
+
+var Doc = React.createClass({
+  render: function () {
+    return (
+      <div id='n1' title='1' className='26'>
+        <dl id='n2' title='2' className='3'>
+          <dt id='n3' title='3' className='1'>dt</dt>
+          <dd id='n4' title='4' className='2'>dd</dd>
+        </dl>
+        <center id='n5' title='5' className='22'>
+          <h1 id='n6' title='6' className='6'>
+            <em id='n7' title='7' className='4'>em</em>
+            <strong id='n8' title='8' className='5'>strong</strong>
+          </h1>
+          <h2 id='n9' title='9' className='9'>
+            <b id='n10' title='10' className='7'>b</b>
+            <s id='n11' title='11' className='8'>s</s>
+          </h2>
+          <blockquote id='n12' title='12' className='15'>
+            blockquoteText1:
+            <br id='n13' title='13' className='10'/>
+            blockquoteText2
+            <p id='n14' title='14' className='13'>
+              <del id='n15' title='15' className='11'>del</del>
+              <ins id='n16' title='16' className='12'>ins</ins>
+            </p>
+            <font id='n17' title='17' className='14' data-face='n8 n26'>font</font>
+          </blockquote>
+          <h3 id='n18' title='18' className='18'>
+            <dfn id='n19' title='19' className='16'>dfn</dfn>
+            <a id='n20' title='20' className='17'>a</a>
+          </h3>
+          <h4 id='n21' title='21' className='21'>
+            <sub id='n22' title='22' className='19'>sub</sub>
+            <sup id='n23' title='23' className='20'>sup</sup>
+          </h4>
+        </center>
+        <span id='n24' title='24' className='25'>
+          <acronym id='n25' title='25' className='23'>acronym</acronym>
+          <q id='n26' title='26' className='24' cite='n8 n17'>q</q>
+        </span>
+      </div>
+    );
+  }
+});
+
+var div = document.createElement("div");
+document.body.appendChild(div);
+var output = ReactDom.render(<Doc />, div);
+
+var assertEvaluatesToNodeSet = Helper.assertEvaluatesToNodeSet.bind(null, output);
+
+suite("XPathReact", function () {
+  suite("basic functional", function () {
+    test("00", function () {
+      assertEvaluatesToNodeSet(".//blockquote/*", ["br", "p", "font"]);
+    });
+
+    test("01", function () {
+      assertEvaluatesToNodeSet(".//blockquote/child::*", ["br", "p", "font"]);
+    });
+
+    test("02", function () {
+      assertEvaluatesToNodeSet(".//blockquote/parent::*", ["center"]);
+    });
+
+    test("03", function () {
+      assertEvaluatesToNodeSet(".//blockquote/descendant::*", ["br", "p", "del", "ins", "font"]);
+    });
+
+    test("04", function () {
+      assertEvaluatesToNodeSet(".//blockquote/descendant-or-self::*", ["blockquote", "br", "p", "del", "ins", "font"]);
+    });
+
+    test("05", function () {
+      assertEvaluatesToNodeSet(".//blockquote/ancestor::*", ["Doc", "div", "center"]);
+    });
+
+    test("06", function () {
+      assertEvaluatesToNodeSet(".//blockquote/ancestor-or-self::*", ["Doc", "div", "center", "blockquote"]);
+    });
+
+    test("07", function () {
+      assertEvaluatesToNodeSet(".//blockquote/following-sibling::*", ["h3", "h4"]);
+    });
+
+    test("08", function () {
+      assertEvaluatesToNodeSet(".//blockquote/preceding-sibling::*", ["h1", "h2"]);
+    });
+
+    test("09", function () {
+      assertEvaluatesToNodeSet(".//blockquote/following::*", ["h3", "dfn", "a", "h4", "sub", "sup", "span", "acronym", "q"]);
+    });
+
+    test("10", function () {
+      assertEvaluatesToNodeSet(".//blockquote/preceding::*", ["dl", "dt", "dd", "h1", "em", "strong", "h2", "b", "s"]);
+    });
+
+    test("11", function () {
+      assertEvaluatesToNodeSet(".//blockquote/self::*", ["blockquote"]);
+    });
+
+    test("12", function () {
+      assertEvaluatesToNodeSet(".//blockquote/attribute::id/parent::*", ["blockquote"]);
+    });
+
+    test("13", function () {
+      assertEvaluatesToNodeSet(".//blockquote/@id/parent::*", ["blockquote"]);
+    });
+
+    test("14", function () {
+      assertEvaluatesToNodeSet(".//*[blockquote]", ["center"]);
+    });
+
+    test("15", function () {
+      assertEvaluatesToNodeSet(".//*[child::blockquote]", ["center"]);
+    });
+
+    test("16", function () {
+      assertEvaluatesToNodeSet(".//*[parent::blockquote]", ["br", "p", "font"]);
+    });
+
+    test("17", function () {
+      assertEvaluatesToNodeSet(".//*[descendant::blockquote]", ["Doc", "div", "center"]);
+    });
+
+    test("18", function () {
+      assertEvaluatesToNodeSet(".//*[descendant-or-self::blockquote]", ["Doc", "div", "center", "blockquote"]);
+    });
+
+    test("19", function () {
+      assertEvaluatesToNodeSet(".//*[ancestor::blockquote]", ["br", "p", "del", "ins", "font"]);
+    });
+
+    test("20", function () {
+      assertEvaluatesToNodeSet(".//*[ancestor-or-self::blockquote]", ["blockquote", "br", "p", "del", "ins", "font"]);
+    });
+
+    test("21", function () {
+      assertEvaluatesToNodeSet(".//*[following-sibling::blockquote]", ["h1", "h2"]);
+    });
+
+    test("22", function () {
+      assertEvaluatesToNodeSet(".//*[preceding-sibling::blockquote]", ["h3", "h4"]);
+    });
+
+    test("23", function () {
+      assertEvaluatesToNodeSet(".//*[following::blockquote]", ["dl", "dt", "dd", "h1", "em", "strong", "h2", "b", "s"]);
+    });
+
+    test("24", function () {
+      assertEvaluatesToNodeSet(".//*[preceding::blockquote]", ["h3", "dfn", "a", "h4", "sub", "sup", "span", "acronym", "q"]);
+    });
+
+    test("25", function () {
+      assertEvaluatesToNodeSet(".//*[self::blockquote]", ["blockquote"]);
+    });
+
+    test("26", function () {
+      assertEvaluatesToNodeSet(".//*[@id]", ["div", "dl", "dt", "dd", "center", "h1", "em", "strong", "h2", "b", "s", "blockquote", "br", "p", "del", "ins", "font", "h3", "dfn", "a", "h4", "sub", "sup", "span", "acronym", "q"]);
+    });
+
+    test("27", function () {
+      assertEvaluatesToNodeSet(".//*[attribute::id]", ["div", "dl", "dt", "dd", "center", "h1", "em", "strong", "h2", "b", "s", "blockquote", "br", "p", "del", "ins", "font", "h3", "dfn", "a", "h4", "sub", "sup", "span", "acronym", "q"]);
+    });
+
+    test("28", function () {
+      assertEvaluatesToNodeSet(".//blockquote/text()", [
+        "text(blockquoteText1:)",
+        "text(blockquoteText2)"
+      ]);
+    });
+
+    test("29", function () {
+      assertEvaluatesToNodeSet(".//blockquote/p", ["p"]);
+    });
+
+    test("30", function () {
+      assertEvaluatesToNodeSet(".//blockquote/*", ["br", "p", "font"]);
+    });
+
+    test("31", function () {
+      assertEvaluatesToNodeSet(".//*[child::* and preceding::font]", ["h3", "h4", "span"]);
+    });
+
+    test("32", function () {
+      assertEvaluatesToNodeSet(".//*[not(child::*) and preceding::font]", ["dfn", "a", "sub", "sup", "acronym", "q"]);
+    });
+
+    test("33", function () {
+      assertEvaluatesToNodeSet(".//*[preceding::blockquote or following::blockquote]", ["dl", "dt", "dd", "h1", "em", "strong", "h2", "b", "s", "h3", "dfn", "a", "h4", "sub", "sup", "span", "acronym", "q"]);
+    });
+
+    test("34", function () {
+      assertEvaluatesToNodeSet(".//blockquote/ancestor::* | .//blockquote/descendant::*", ["Doc", "div", "center", "br", "p", "del", "ins", "font"]);
+    });
+
+    test("35", function () {
+      assertEvaluatesToNodeSet(".//*[.='sub']", ["sub"]);
+    });
+
+    test("36", function () {
+      assertEvaluatesToNodeSet(".//*[@title > 12 and @class < 15]", ["br", "p", "del", "ins", "font"]);
+    });
+
+    test("37", function () {
+      assertEvaluatesToNodeSet(".//*[@title != @class]", ["div", "dl", "dt", "dd", "center", "em", "strong", "b", "s", "blockquote", "br", "p", "del", "ins", "font", "dfn", "a", "sub", "sup", "span", "acronym", "q"]);
+    });
+
+    test("38", function () {
+      assertEvaluatesToNodeSet(".//*[((@class * @class + @title * @title) div (@class + @title)) > ((@class - @title) * (@class - @title))]", ["dl", "h1", "h2", "s", "blockquote", "br", "p", "font", "h3", "dfn", "a", "h4", "sub", "sup", "span", "acronym", "q"]);
+    });
+
+    test("39", function () {
+      assertEvaluatesToNodeSet(".//*[@title mod 2 = 0]", ["Doc", "dl", "dd", "h1", "strong", "b", "blockquote", "p", "ins", "h3", "a", "sub", "span", "q"]);
+    });
+
+    test("40", function () {
+      assertEvaluatesToNodeSet(".//blockquote/child::*[last()]", ["font"]);
+    });
+
+    test("41", function () {
+      assertEvaluatesToNodeSet(".//blockquote/descendant::*[position() < 4]", ["br", "p", "del"]);
+    });
+
+    test("42", function () {
+      assertEvaluatesToNodeSet("id(.//font/@data-face)", ["strong", "q"]);
+    });
+
+    test("45", function () {
+      assertEvaluatesToNodeSet(".//blockquote/child::*[2]", ["p"]);
+    });
+
+    test("46", function () {
+      assertEvaluatesToNodeSet(".//blockquote/descendant::*[4]", ["ins"]);
+    });
+
+    test("47", function () {
+      assertEvaluatesToNodeSet(".//blockquote/descendant-or-self::*[4]", ["del"]);
+    });
+
+    test("48", function () {
+      assertEvaluatesToNodeSet(".//blockquote/ancestor::*[2]", ["div"]);
+    });
+
+    test("49", function () {
+      assertEvaluatesToNodeSet(".//blockquote/ancestor-or-self::*[2]", ["center"]);
+    });
+
+    test("50", function () {
+      assertEvaluatesToNodeSet(".//blockquote/following-sibling::*[1]", ["h3"]);
+    });
+
+    test("51", function () {
+      assertEvaluatesToNodeSet(".//blockquote/preceding-sibling::*[1]", ["h2"]);
+    });
+
+    test("52", function () {
+      assertEvaluatesToNodeSet(".//blockquote/following::*[4]", ["h4"]);
+    });
+
+    test("53", function () {
+      assertEvaluatesToNodeSet(".//blockquote/preceding::*[4]", ["strong"]);
+    });
+
+    test("54", function () {
+      assertEvaluatesToNodeSet(".//*[starts-with(.,'s')]", ["strong", "s", "h4", "sub", "sup"]);
+    });
+
+    test("55", function () {
+      assertEvaluatesToNodeSet(".//*[string(@title - 1) = '0']", ["div"]);
+    });
+
+    test("56", function () {
+      assertEvaluatesToNodeSet(".//*[string() = 'sub']", ["sub"]);
+    });
+
+    test("57", function () {
+      assertEvaluatesToNodeSet(".//*[string(.) = 'sub']", ["sub"]);
+    });
+
+    // Why does this fail?
+    test("58", function () {
+      assertEvaluatesToNodeSet(".//*[normalize-space(concat(.,..)) = 'subsubsup']", ["sub"]);
+    });
+
+    test("59", function () {
+      assertEvaluatesToNodeSet("/sub[concat(.,..) = 'subsub sup ']", []);
+    });
+
+    test("60", function () {
+      assertEvaluatesToNodeSet(".//node()[normalize-space(concat(.,..,../..)) = 'bbbs']", ["text(b)"]);
+    });
+
+    test("61", function () {
+      assertEvaluatesToNodeSet(".//node()[concat(.,..,../..) = 'bbb s ']", []);
+    });
+
+    test("62", function () {
+      assertEvaluatesToNodeSet(".//*[substring-before(.,'u') = 's']", ["h4", "sub", "sup"]);
+    });
+
+    test("63", function () {
+      assertEvaluatesToNodeSet(".//*[substring-after(.,'on') = 't']", ["blockquote", "font"]);
+    });
+
+    test("64", function () {
+      assertEvaluatesToNodeSet(".//*[substring(.,2,1) = 'u']", ["h4", "sub", "sup"]);
+    });
+
+    test("65", function () {
+      assertEvaluatesToNodeSet(".//*[substring(.,2) = 'up']", ["sup"]);
+    });
+
+    test("66", function () {
+      assertEvaluatesToNodeSet(".//*[contains(.,'b')]", ["Doc", "div", "center", "h2", "b", "blockquote", "h4", "sub"]);
+    });
+
+    test("67", function () {
+      assertEvaluatesToNodeSet(".//*[name() != 'dt' and name() != 'dd' and string-length() = 3]", ["del", "ins", "dfn", "sub", "sup"]);
+    });
+
+    test("68", function () {
+      assertEvaluatesToNodeSet(".//*[string-length(normalize-space(.)) = 3]", ["del", "ins", "dfn", "sub", "sup"]);
+    });
+
+    test("69", function () {
+      assertEvaluatesToNodeSet(".//*[.=translate(normalize-space('  s  u  b  '),' ','')]", ["sub"]);
+    });
+
+    test("70", function () {
+      assertEvaluatesToNodeSet(".//*[normalize-space()='q']", ["q"]);
+    });
+
+    test("71", function () {
+      assertEvaluatesToNodeSet(".//*[boolean(@title - 1) = false()]", ["div"]);
+    });
+
+    test("72", function () {
+      assertEvaluatesToNodeSet(".//*[not(@title - 1) = true()]", ["div"]);
+    });
+
+    test("73", function () {
+      assertEvaluatesToNodeSet(".//*[number(@title) < number(@class)]", ["div", "dl", "center", "blockquote", "span"]);
+    });
+
+    test("74", function () {
+      assertEvaluatesToNodeSet(".//*[sum(ancestor::*/@title) < sum(descendant::*/@title)]", ["Doc", "div", "dl", "center", "h1", "h2", "blockquote", "p", "h3", "h4", "span"]);
+    });
+
+    test("75", function () {
+      assertEvaluatesToNodeSet(".//*[floor(@title div @class) = 1]", ["h1", "em", "strong", "h2", "b", "s", "br", "p", "del", "ins", "font", "h3", "dfn", "a", "h4", "sub", "sup", "acronym", "q"]);
+    });
+
+    test("76", function () {
+      assertEvaluatesToNodeSet(".//*[ceiling(@title div @class) = 1]", ["div", "dl", "center", "h1", "h2", "blockquote", "h3", "h4", "span"]);
+    });
+
+    test("77", function () {
+      assertEvaluatesToNodeSet(".//*[round(@title div @class) = 1]", ["dl", "h1", "h2", "b", "s", "blockquote", "br", "p", "del", "ins", "font", "h3", "dfn", "a", "h4", "sub", "sup", "span", "acronym", "q"]);
+    });
+
+    test("78", function () {
+      assertEvaluatesToNodeSet("/..", []);
+    });
+  });
+});

--- a/test/dom_child_component_test.js
+++ b/test/dom_child_component_test.js
@@ -7,8 +7,6 @@ var XPathEvaluator = require("../index");
 var React = require("react");
 var ReactDom = require("react-dom");
 
-var Helper = require("./helper");
-
 var jsdom = require("jsdom");
 
 function initDOM() {

--- a/test/dom_child_component_test.js
+++ b/test/dom_child_component_test.js
@@ -1,0 +1,121 @@
+"use strict";
+
+var Assert = require("assert");
+
+var XPathEvaluator = require("../index");
+
+var React = require("react");
+var ReactDom = require("react-dom");
+
+var Helper = require("./helper");
+
+var jsdom = require("jsdom");
+
+function initDOM() {
+  global.document = jsdom.jsdom("");
+  global.window = document.defaultView;
+  global.navigator = window.navigator;
+}
+
+var Foo = React.createClass({
+  render: function () {
+    return (
+      <div>
+        <p>Hello world!</p>
+      </div>
+    );
+  }
+});
+
+var Bar = React.createClass({
+  render: function () {
+    return (
+      <div>
+        Foo: <Foo />
+      </div>
+    );
+  }
+});
+
+suite("XPathReact", function () {
+  suite("child component", function () {
+    test("Child component", function () {
+      initDOM();
+
+      var div = document.createElement("div");
+      document.body.appendChild(div);
+      var output = ReactDom.render(<Bar />, div);
+
+      var expression = ".//Foo";
+
+      var result = XPathEvaluator.evaluate(expression, output, null, XPathEvaluator.XPathResult.ANY_UNORDERED_NODE_TYPE);
+
+      Assert.equal(result.singleNodeValue.type, Foo);
+    });
+
+    test("Child component (complex)", function () {
+      initDOM();
+
+      var div = document.createElement("div");
+      document.body.appendChild(div);
+      var output = ReactDom.render(<Bar />, div);
+
+      var expression = "string(.//Foo/parent::*)";
+
+      var result = XPathEvaluator.evaluate(expression, output, null, XPathEvaluator.XPathResult.STRING_TYPE);
+
+      Assert.equal(result.stringValue, "Foo: Hello world!");
+    });
+
+    test("Child component (functional component)", function () {
+      function Qux () {
+        return <span>Hello world!</span>;
+      }
+
+      var Norf = React.createClass({
+        render: function () {
+          return <p><Qux /></p>;
+        }
+      });
+
+      initDOM();
+
+      var div = document.createElement("div");
+      document.body.appendChild(div);
+      var output = ReactDom.render(<Norf />, div);
+
+      var expression = ".//Qux";
+
+      var result = XPathEvaluator.evaluate(expression, output, null, XPathEvaluator.XPathResult.ANY_UNORDERED_NODE_TYPE);
+
+      Assert.equal(result.singleNodeValue.type, Qux);
+    });
+
+    test("two-dimensional child components", function () {
+      var Qux = React.createClass({
+        render: function() {
+          return (
+            <div>
+              <p />
+              {[1, 2, 3].map(function (number) {
+                return <p key={number} />;
+              })}
+            </div>
+          );
+        }
+      });
+
+      initDOM();
+
+      var div = document.createElement("div");
+      document.body.appendChild(div);
+      var output = ReactDom.render(<Qux />, div);
+      
+      var expression = "count(//p)";
+
+      var result = XPathEvaluator.evaluate(expression, output, null, XPathEvaluator.XPathResult.NUMBER_TYPE);
+
+      Assert.equal(result.numberValue, 4);
+    });
+  });
+});

--- a/test/dom_complex_hrex_test.js
+++ b/test/dom_complex_hrex_test.js
@@ -1,0 +1,67 @@
+"use strict";
+
+var React = require("react");
+var ReactDom = require("react-dom");
+
+var Helper = require("./helper");
+
+var jsdom = require("jsdom");
+
+global.document = jsdom.jsdom("");
+global.window = document.defaultView;
+global.navigator = window.navigator;
+
+/* eslint-disable no-script-url */
+var Doc = React.createClass({
+  render: function () {
+    return (
+      <div>
+        <a id='id0-0' href='javascript:doFoo(a, b)'>foo</a>
+        <a id='id0-1' href='javascript:doFoo(a, %20b)'>foo</a>
+        <a id='id0-2' href='javascript:doFoo(%61, %20b)'>foo</a>
+        <a id='id1-0' href='http://example.com/a b'>foo</a>
+        <a id='id1-1' href='http://example.com/a%20b'>foo</a>
+        <a id='id1-2' href='http://example.com/%61%20b'>foo</a>
+      </div>
+    );
+  }
+});
+
+var div = document.createElement("div");
+document.body.appendChild(div);
+var output = ReactDom.render(<Doc />, div);
+/* eslint-ena enable no-script-url */
+
+var assertEvaluatesToNodeSet = Helper.assertEvaluatesToNodeSet.bind(null, output);
+
+suite("XPathReact", function () {
+  suite("complex href", function () {
+    test("00", function () {
+      assertEvaluatesToNodeSet("//a[@href='javascript:doFoo(a, b)']", ["a#id0-0"]);
+    });
+
+    test("01", function () {
+      assertEvaluatesToNodeSet("//a[@href='javascript:doFoo(a, %20b)']", ["a#id0-1"]);
+    });
+
+    test("02", function () {
+      assertEvaluatesToNodeSet("//a[@href='javascript:doFoo(%61, %20b)']", ["a#id0-2"]);
+    });
+
+    test("03", function () {
+      assertEvaluatesToNodeSet("//a[@href='http://example.com/a b']", ["a#id1-0"]);
+    });
+
+    test("04", function () {
+      assertEvaluatesToNodeSet("//a[@href='http://example.com/a%20b']", ["a#id1-1"]);
+    });
+
+    test("05", function () {
+      assertEvaluatesToNodeSet("//a[@href='http://example.com/%61%20b']", ["a#id1-2"]);
+    });
+
+    test("06", function () {
+      assertEvaluatesToNodeSet("//*[@href='http://example.com/a b'][@href='http://example.com/a b']", ["a#id1-0"]);
+    });
+  });
+});

--- a/test/dom_descendant_test.js
+++ b/test/dom_descendant_test.js
@@ -1,0 +1,130 @@
+"use strict";
+
+var React = require("react");
+var ReactDom = require("react-dom");
+
+var Helper = require("./helper");
+
+var jsdom = require("jsdom");
+
+global.document = jsdom.jsdom("");
+global.window = document.defaultView;
+global.navigator = window.navigator;
+
+var Doc = React.createClass({
+  render: function () {
+    return (
+      <section>
+        <div>
+          <h1>foo</h1>
+        </div>
+      </section>
+    );
+  }
+});
+
+var div = document.createElement("div");
+document.body.appendChild(div);
+var output = ReactDom.render(<Doc />, div);
+
+var assertEvaluatesToNodeSet = Helper.assertEvaluatesToNodeSet.bind(null, output);
+
+suite("XPathReact", function () {
+  suite("descendant", function () {
+    test("00", function () {
+      assertEvaluatesToNodeSet("//*", ["Doc", "section", "div", "h1"]);
+    });
+
+    test("01", function () {
+      assertEvaluatesToNodeSet("//node()", ["Doc", "section", "div", "h1", "text(foo)"]);
+    });
+
+    test("02", function () {
+      assertEvaluatesToNodeSet("/descendant::*", ["Doc", "section", "div", "h1"]);
+    });
+
+    test("03", function () {
+      assertEvaluatesToNodeSet("/descendant::node()", ["Doc", "section", "div", "h1", "text(foo)"]);
+    });
+
+    test("04", function () {
+      assertEvaluatesToNodeSet("/descendant-or-self::*", ["Doc", "section", "div", "h1"]);
+    });
+
+    test.skip("05", function () {
+      assertEvaluatesToNodeSet("/self::node()", ["document()", "Doc", "section", "div", "h1", "text(foo)"]);
+    });
+
+    test("06", function () {
+      assertEvaluatesToNodeSet("//*//*", ["section", "div", "h1"]);
+    });
+
+    test("07", function () {
+      assertEvaluatesToNodeSet("//node()//node()", ["section", "div", "h1", "text(foo)"]);
+    });
+
+    test("08", function () {
+      assertEvaluatesToNodeSet("//*/descendant::*", ["section", "div", "h1"]);
+    });
+
+    test("09", function () {
+      assertEvaluatesToNodeSet("//node()/descendant::node()", ["section", "div", "h1", "text(foo)"]);
+    });
+
+    test("10", function () {
+      assertEvaluatesToNodeSet("//*/descendant-or-self::*", ["Doc", "section", "div", "h1"]);
+    });
+
+    test("11", function () {
+      assertEvaluatesToNodeSet("//node()/descendant-or-self::node()", ["Doc", "section", "div", "h1", "text(foo)"]);
+    });
+
+    test("12", function () {
+      assertEvaluatesToNodeSet("//*[1]", ["Doc", "section", "div", "h1"]);
+    });
+
+    test("13", function () {
+      assertEvaluatesToNodeSet("//node()[1]", ["Doc", "section", "div", "h1", "text(foo)"]);
+    });
+
+    test("14", function () {
+      assertEvaluatesToNodeSet("/descendant::*[1]", ["Doc"]);
+    });
+
+    test("15", function () {
+      assertEvaluatesToNodeSet("/descendant::node()[1]", ["Doc"]);
+    });
+
+    test("16", function () {
+      assertEvaluatesToNodeSet("/descendant-or-self::*[1]", ["Doc"]);
+    });
+
+    test.skip("17", function () {
+      assertEvaluatesToNodeSet("/descendant-or-self::node()[1]", ["document()"]);
+    });
+
+    test("18", function () {
+      assertEvaluatesToNodeSet("//*//*[1]", ["section", "div", "h1"]);
+    });
+
+    test("19", function () {
+      assertEvaluatesToNodeSet("//node()//node()[1]", ["section", "div", "h1", "text(foo)"]);
+    });
+
+    test("20", function () {
+      assertEvaluatesToNodeSet("//*/descendant::*[1]", ["section", "div", "h1"]);
+    });
+
+    test("21", function () {
+      assertEvaluatesToNodeSet("//node()/descendant::node()[1]", ["section", "div", "h1", "text(foo)"]);
+    });
+
+    test("22", function () {
+      assertEvaluatesToNodeSet("//*/descendant-or-self::*[1]", ["Doc", "section", "div", "h1"]);
+    });
+
+    test("23", function () {
+      assertEvaluatesToNodeSet("//node()/descendant-or-self::node()[1]", ["Doc", "section", "div", "h1", "text(foo)"]);
+    });
+  });
+});

--- a/test/dom_double_slash_and_descendant_test.js
+++ b/test/dom_double_slash_and_descendant_test.js
@@ -1,0 +1,76 @@
+"use strict";
+
+var React = require("react");
+var ReactDom = require("react-dom");
+
+var Helper = require("./helper");
+
+var jsdom = require("jsdom");
+
+global.document = jsdom.jsdom("");
+global.window = document.defaultView;
+global.navigator = window.navigator;
+
+var Doc = React.createClass({
+  render: function () {
+    return (
+      <section>
+        <div id='parent'>
+          <div id='child-1'>
+            <div id='grand-child-1-1'></div>
+            <p>dust</p>
+            <div id='grand-child-1-2'></div>
+            <p>dust</p>
+            <div id='grand-child-1-3'></div>
+          </div>
+          <p>dust</p>
+          <div id='child-2'>
+            <div id='grand-child-2-1'></div>
+            <p>dust</p>
+            <div id='grand-child-2-2'></div>
+            <p>dust</p>
+            <div id='grand-child-2-3'></div>
+          </div>
+        </div>
+      </section>
+    );
+  }
+});
+
+var div = document.createElement("div");
+document.body.appendChild(div);
+var output = ReactDom.render(<Doc />, div);
+
+var assertEvaluatesToNodeSet = Helper.assertEvaluatesToNodeSet.bind(null, output);
+
+suite("XPathReact", function () {
+  suite("double slash and descendant", function () {
+    test("00", function () {
+      assertEvaluatesToNodeSet("/descendant::div", ["div#parent", "div#child-1", "div#grand-child-1-1", "div#grand-child-1-2", "div#grand-child-1-3", "div#child-2", "div#grand-child-2-1", "div#grand-child-2-2", "div#grand-child-2-3"]);
+    });
+
+    test("01", function () {
+      assertEvaluatesToNodeSet("//section/descendant::*", ["div#parent", "div#child-1", "div#grand-child-1-1", "p", "div#grand-child-1-2", "p", "div#grand-child-1-3", "p", "div#child-2", "div#grand-child-2-1", "p", "div#grand-child-2-2", "p", "div#grand-child-2-3"]);
+    });
+
+    test("02", function () {
+      assertEvaluatesToNodeSet("/descendant::div[1]", ["div#parent"]);
+    });
+
+    test("03", function () {
+      assertEvaluatesToNodeSet("//div", ["div#parent", "div#child-1", "div#grand-child-1-1", "div#grand-child-1-2", "div#grand-child-1-3", "div#child-2", "div#grand-child-2-1", "div#grand-child-2-2", "div#grand-child-2-3"]);
+    });
+
+    test("04", function () {
+      assertEvaluatesToNodeSet("//section//*", ["div#parent", "div#child-1", "div#grand-child-1-1", "p", "div#grand-child-1-2", "p", "div#grand-child-1-3", "p", "div#child-2", "div#grand-child-2-1", "p", "div#grand-child-2-2", "p", "div#grand-child-2-3"]);
+    });
+
+    test("05", function () {
+      assertEvaluatesToNodeSet("//div[1]", ["div#parent", "div#child-1", "div#grand-child-1-1", "div#grand-child-2-1"]);
+    });
+
+    test("06", function () {
+      assertEvaluatesToNodeSet("//div[contains(@id, 'grand-child')]", ["div#grand-child-1-1", "div#grand-child-1-2", "div#grand-child-1-3", "div#grand-child-2-1", "div#grand-child-2-2", "div#grand-child-2-3"]);
+    });
+  });
+});

--- a/test/dom_element_had_length_property_test.js
+++ b/test/dom_element_had_length_property_test.js
@@ -1,0 +1,100 @@
+"use strict";
+
+var React = require("react");
+var ReactDom = require("react-dom");
+
+var Helper = require("./helper");
+
+var jsdom = require("jsdom");
+
+global.document = jsdom.jsdom("");
+global.window = document.defaultView;
+global.navigator = window.navigator;
+
+var Doc = React.createClass({
+  render: function () {
+    return (
+      <section>
+        <select id='target'>
+          <option>foo</option>
+          <option>bar</option>
+          <option>baz</option>
+        </select>
+        <div>
+          <select name='target2' id='a'>
+            <option>foo</option>
+            <option>bar</option>
+            <option>baz</option>
+          </select>
+          <select name='target2' id='b'>
+            <option>foo</option>
+            <option>bar</option>
+            <option>baz</option>
+          </select>
+        </div>
+      </section>
+    );
+  }
+});
+
+var div = document.createElement("div");
+document.body.appendChild(div);
+var output = ReactDom.render(<Doc />, div);
+
+var assertEvaluatesToNodeSet = Helper.assertEvaluatesToNodeSet.bind(null, output);
+
+suite("XPathReact", function () {
+  suite("element had length property", function () {
+    test("00", function () {
+      assertEvaluatesToNodeSet("id('target')", ["select#target"]);
+    });
+
+    test("01", function () {
+      assertEvaluatesToNodeSet("//*[@id='target']", ["select#target"]);
+    });
+
+    test("02", function () {
+      assertEvaluatesToNodeSet("//select[@id='target']", ["select#target"]);
+    });
+
+    test("03", function () {
+      assertEvaluatesToNodeSet("//node()[@id='target']", ["select#target"]);
+    });
+
+    test("04", function () {
+      assertEvaluatesToNodeSet("//section/*[@id='target']", ["select#target"]);
+    });
+
+    test("05", function () {
+      assertEvaluatesToNodeSet("//section/select[@id='target']", ["select#target"]);
+    });
+
+    test("06", function () {
+      assertEvaluatesToNodeSet("//section/node()[@id='target']", ["select#target"]);
+    });
+
+    test("08", function () {
+      assertEvaluatesToNodeSet("//*[@name='target2']", ["select#a", "select#b"]);
+    });
+
+    test("09", function () {
+      assertEvaluatesToNodeSet("//select[@name='target2']", ["select#a", "select#b"]);
+    });
+
+    test("10", function () {
+      assertEvaluatesToNodeSet("//node()[@name='target2']", ["select#a", "select#b"]);
+    });
+
+    test("11", function () {
+      assertEvaluatesToNodeSet("//section/div/*[@name='target2']", ["select#a", "select#b"]);
+    });
+
+    test("12", function () {
+      assertEvaluatesToNodeSet("//section/div/select[@name='target2']", ["select#a", "select#b"]);
+    });
+
+    test("13", function () {
+      assertEvaluatesToNodeSet("//section/div/node()[@name='target2']", ["select#a", "select#b"]);
+    });
+  });
+});

--- a/test/dom_id_test.js
+++ b/test/dom_id_test.js
@@ -1,0 +1,64 @@
+"use strict";
+
+var React = require("react");
+var ReactDom = require("react-dom");
+
+var Helper = require("./helper");
+
+var jsdom = require("jsdom");
+
+global.document = jsdom.jsdom("");
+global.window = document.defaultView;
+global.navigator = window.navigator;
+
+var Doc = React.createClass({
+  render: function () {
+    return (
+      <div>
+          <div id='dupeid'>My id is dupeid</div>
+          <div id='dupeid'>My id is also dupeid</div>
+          <div id='uniqueid'>My id is uniqueid</div>
+      </div>
+    );
+  }
+});
+
+var div = document.createElement("div");
+document.body.appendChild(div);
+var output = ReactDom.render(<Doc />, div);
+
+var assertEvaluatesToNodeSet = Helper.assertEvaluatesToNodeSet.bind(null, output);
+
+var assertEvaluatesToValue = Helper.assertEvaluatesToValue.bind(null, output);
+
+suite("XPathReact", function () {
+  suite("id", function () {
+    test("with unique id by function", function () {
+      assertEvaluatesToNodeSet("id('uniqueid')", ["div#uniqueid"]);
+    });
+
+    test("with dupe id by function", function () {
+      assertEvaluatesToNodeSet("id('dupeid')", ["div#dupeid"]);
+    });
+
+    test("with unique id by attribute", function () {
+      assertEvaluatesToNodeSet("//*[@id='uniqueid']", ["div#uniqueid"]);
+    });
+
+    test("with dupe id by attribute", function () {
+      assertEvaluatesToNodeSet("//*[@id='dupeid']", ["div#dupeid", "div#dupeid"]);
+    });
+
+    test("with id by function in a attribute node context", function () {
+      assertEvaluatesToValue("boolean(//attribute::*[id('uniqueid')])", true);
+    });
+
+    test("with id by function in a text node context", function () {
+      assertEvaluatesToValue("boolean(//text()[id('uniqueid')])", true);
+    });
+
+    test("with id by function in a element node context", function () {
+      assertEvaluatesToValue("boolean(//child::*[id('uniqueid')])", true);
+    });
+  });
+});

--- a/test/dom_inline_svg_test.js
+++ b/test/dom_inline_svg_test.js
@@ -1,0 +1,54 @@
+"use strict";
+
+var React = require("react");
+var ReactDom = require("react-dom");
+
+var Helper = require("./helper");
+
+var jsdom = require("jsdom");
+
+global.document = jsdom.jsdom("");
+global.window = document.defaultView;
+global.navigator = window.navigator;
+
+var Doc = React.createClass({
+  render: function () {
+    return (
+      <div>
+        <svg id='svg' xmlns='http://www.w3.org/2000/svg' version='1.1' viewBox='0 0 1000 50'>
+          <rect id='rect' fill='red' stroke='none' height='12' width='12' y='20' x='100'></rect>
+          <text id='text' fill='black' fontSize='12' fontFamily='Arial' y='30' x='115'>Apple</text>
+          <path id='path' d='M 200 26 L 600 26' stroke='red' strokeWidth='1em'/>
+        </svg>
+      </div>
+    );
+  }
+});
+
+var div = document.createElement("div");
+document.body.appendChild(div);
+var output = ReactDom.render(<Doc />, div);
+
+var assertEvaluatesToNodeSet = Helper.assertEvaluatesToNodeSet.bind(null, output);
+
+// TODO: Use a namespace prefix once support for namespaces are implemented.
+
+suite("XPathReact", function () {
+  suite("inline svg", function () {
+    test("00", function () {
+      assertEvaluatesToNodeSet("//svg", ["svg#svg"]);
+    });
+
+    test("01", function () {
+      assertEvaluatesToNodeSet("//rect", ["rect#rect"]);
+    });
+
+    test("02", function () {
+      assertEvaluatesToNodeSet("//text", ["text#text"]);
+    });
+
+    test("03", function () {
+      assertEvaluatesToNodeSet("//path", ["path#path"]);
+    });
+  });
+});

--- a/test/dom_math_test.js
+++ b/test/dom_math_test.js
@@ -1,0 +1,41 @@
+"use strict";
+
+var React = require("react");
+var ReactDom = require("react-dom");
+
+var Helper = require("./helper");
+
+var jsdom = require("jsdom");
+
+global.document = jsdom.jsdom("");
+global.window = document.defaultView;
+global.navigator = window.navigator;
+
+var Doc = React.createClass({
+  render: function () {
+    return (
+      <div>
+        <div id='with' data-price='2' data-count='3'></div>
+        <div id='without' data-price='2' data-count='4'></div>
+      </div>
+    );
+  }
+});
+
+var div = document.createElement("div");
+document.body.appendChild(div);
+var output = ReactDom.render(<Doc />, div);
+
+var assertEvaluatesToNodeSet = Helper.assertEvaluatesToNodeSet.bind(null, output);
+
+suite("XPathReact", function () {
+  suite("math", function () {
+    test("00", function () {
+      assertEvaluatesToNodeSet("//*[@data-price * (@data-count + @data-count) = 12]", ["div#with"]);
+    });
+
+    test("01", function () {
+      assertEvaluatesToNodeSet("//*[@data-price * @data-count + @data-count = 12]", ["div#without"]);
+    });
+  });
+});

--- a/test/dom_misc_test.js
+++ b/test/dom_misc_test.js
@@ -1,0 +1,92 @@
+"use strict";
+
+var React = require("react");
+var ReactDom = require("react-dom");
+
+var Helper = require("./helper");
+
+var jsdom = require("jsdom");
+
+global.document = jsdom.jsdom("");
+global.window = document.defaultView;
+global.navigator = window.navigator;
+
+var Doc = React.createClass({
+  render: function () {
+    return (
+      <section>
+        <div id='id1'>foo</div>
+        <div id='id2'>bar</div>
+        <div id='id3'>baz</div>
+        <div id='id4'>
+          <div id='id4-1'>foo</div>
+          <div id='id4-2'>bar</div>
+          <div id='id4-3'>baz</div>
+        </div>
+        <table>
+          <tbody>
+            <tr id='id5'><td>1</td><td>2</td></tr>
+            <tr id='id6'><td>1</td><td>2</td></tr>
+            <tr id='id7'><td>1</td><td>2</td></tr>
+          </tbody>
+        </table>
+        <table>
+          <tbody>
+            <tr id='id8'><td>1</td><td>2</td></tr>
+            <tr id='id9'><td>1</td><td>2</td></tr>
+            <tr id='id0'><td>1</td><td>2</td></tr>
+          </tbody>
+        </table>
+        <p id='ppp'>1</p>
+      </section>
+    );
+  }
+});
+
+var div = document.createElement("div");
+document.body.appendChild(div);
+var output = ReactDom.render(<Doc />, div);
+
+var assertEvaluatesToNodeSet = Helper.assertEvaluatesToNodeSet.bind(null, output);
+
+var assertEvaluatesToValue = Helper.assertEvaluatesToValue.bind(null, output);
+
+suite("XPathReact", function () {
+  suite("misc", function () {
+    test("00", function () {
+      assertEvaluatesToNodeSet("//div[2]", ["div#id2", "div#id4-2"]);
+    });
+
+    test("01", function () {
+      assertEvaluatesToNodeSet("/descendant::div[2]", ["div#id2"]);
+    });
+
+    test("02", function () {
+      assertEvaluatesToNodeSet("(//div)[2]", ["div#id2"]);
+    });
+
+    test("03", function () {
+      assertEvaluatesToNodeSet("//tr[2]", ["tr#id6", "tr#id9"]);
+    });
+
+    test("04", function () {
+      assertEvaluatesToNodeSet("/descendant::tr[2]", ["tr#id6"]);
+    });
+
+    test("05", function () {
+      assertEvaluatesToNodeSet("(//tr)[2]", ["tr#id6"]);
+    });
+
+    test("07", function () {
+      assertEvaluatesToNodeSet("id('ppp')[true()]", ["p#ppp"]);
+    });
+
+    test("08", function () {
+      assertEvaluatesToValue("number(id('ppp')[true()])", 1);
+    });
+
+    test("09", function () {
+      assertEvaluatesToValue("id('ppp')[true()] + 1", 2);
+    });
+  });
+});

--- a/test/dom_name_test.js
+++ b/test/dom_name_test.js
@@ -1,0 +1,43 @@
+"use strict";
+
+var React = require("react");
+var ReactDom = require("react-dom");
+
+var Helper = require("./helper");
+
+var jsdom = require("jsdom");
+
+global.document = jsdom.jsdom("");
+global.window = document.defaultView;
+global.navigator = window.navigator;
+
+var Doc = React.createClass({
+  render: function () {
+    return (
+      <div>
+        <div name='single' id='single'>div element 1</div>
+        <div name='duplicate' id='duplicate_1'>div element 2</div>
+        <div name='duplicate' id='duplicate_2'>div element 3</div>
+        <div name='duplicate' id='duplicate_3'>div element 4</div>
+      </div>
+    );
+  }
+});
+
+var div = document.createElement("div");
+document.body.appendChild(div);
+var output = ReactDom.render(<Doc />, div);
+
+var assertEvaluatesToNodeSet = Helper.assertEvaluatesToNodeSet.bind(null, output);
+
+suite("XPathReact", function () {
+  suite("name", function () {
+    test("unique name", function () {
+      assertEvaluatesToNodeSet("//*[@name='single']", ["div#single"]);
+    });
+
+    test("01", function () {
+      assertEvaluatesToNodeSet("//*[@name='duplicate']", ["div#duplicate_1", "div#duplicate_2", "div#duplicate_3"]);
+    });
+  });
+});

--- a/test/dom_preceding_and_following_test.js
+++ b/test/dom_preceding_and_following_test.js
@@ -1,0 +1,161 @@
+"use strict";
+
+var React = require("react");
+var ReactDom = require("react-dom");
+
+var Helper = require("./helper");
+
+var jsdom = require("jsdom");
+
+global.document = jsdom.jsdom("");
+global.window = document.defaultView;
+global.navigator = window.navigator;
+
+var Doc = React.createClass({
+  render: function () {
+    return (
+      <section>
+        <div>
+          <p className='1'></p>
+          <ul>
+            <li id='t1'></li>
+            <li></li>
+            <li id='t2'></li>
+          </ul>
+          <p className='2'></p>
+        </div>
+        <div>
+         <p className='3'></p>
+         <ul>
+           <li id='t3'></li>
+           <li></li>
+           <li id='t4'></li>
+         </ul>
+         <p className='4'></p>
+        </div>
+      </section>
+    );
+  }
+});
+
+var div = document.createElement("div");
+document.body.appendChild(div);
+var output = ReactDom.render(<Doc />, div);
+
+var assertEvaluatesToNodeSet = Helper.assertEvaluatesToNodeSet.bind(null, output);
+
+suite("XPathReact", function () {
+  suite("preceding and following", function () {
+    test("00", function () {
+      assertEvaluatesToNodeSet("id('t1')/following::*", ["li", "li#t2", "p.2", "div", "p.3", "ul", "li#t3", "li", "li#t4", "p.4"]);
+    });
+
+    test("01", function () {
+      assertEvaluatesToNodeSet("id('t2')/following::*", ["p.2", "div", "p.3", "ul", "li#t3", "li", "li#t4", "p.4"]);
+    });
+
+    test("02", function () {
+      assertEvaluatesToNodeSet("id('t3')/following::*", ["li", "li#t4", "p.4"]);
+    });
+
+    test("03", function () {
+      assertEvaluatesToNodeSet("id('t4')/following::*", ["p.4"]);
+    });
+
+    test("04", function () {
+      assertEvaluatesToNodeSet("id('t3 t4')/following::*", ["li", "li#t4", "p.4"]);
+    });
+
+    test("05", function () {
+      assertEvaluatesToNodeSet("id('t2 t3 t4')/following::*", ["p.2", "div", "p.3", "ul", "li#t3", "li", "li#t4", "p.4"]);
+    });
+
+    test("06", function () {
+      assertEvaluatesToNodeSet("id('t1 t2 t3 t4')/following::*", ["li", "li#t2", "p.2", "div", "p.3", "ul", "li#t3", "li", "li#t4", "p.4"]);
+    });
+
+    test("07", function () {
+      assertEvaluatesToNodeSet("id('t1 t2 t3 t4')/preceding::*", ["div", "p.1", "ul", "li#t1", "li", "li#t2", "p.2", "p.3", "li#t3", "li"]);
+    });
+
+    test("08", function () {
+      assertEvaluatesToNodeSet("id('t1 t2 t3')/preceding::*", ["div", "p.1", "ul", "li#t1", "li", "li#t2", "p.2", "p.3"]);
+    });
+
+    test("09", function () {
+      assertEvaluatesToNodeSet("id('t1 t2')/preceding::*", ["p.1", "li#t1", "li"]);
+    });
+
+    test("10", function () {
+      assertEvaluatesToNodeSet("id('t1')/preceding::*", ["p.1"]);
+    });
+
+    test("11", function () {
+      assertEvaluatesToNodeSet("id('t2')/preceding::*", ["p.1", "li#t1", "li"]);
+    });
+
+    test("12", function () {
+      assertEvaluatesToNodeSet("id('t3')/preceding::*", ["div", "p.1", "ul", "li#t1", "li", "li#t2", "p.2", "p.3"]);
+    });
+
+    test("13", function () {
+      assertEvaluatesToNodeSet("id('t4')/preceding::*", ["div", "p.1", "ul", "li#t1", "li", "li#t2", "p.2", "p.3", "li#t3", "li"]);
+    });
+
+    test("14", function () {
+      assertEvaluatesToNodeSet("id('t1')/following::*[1]", ["li"]);
+    });
+
+    test("15", function () {
+      assertEvaluatesToNodeSet("id('t2')/following::*[1]", ["p.2"]);
+    });
+
+    test("16", function () {
+      assertEvaluatesToNodeSet("id(\"t3\")/following::*[1]", ["li"]);
+    });
+
+    test("17", function () {
+      assertEvaluatesToNodeSet("id(\"t4\")/following::*[1]", ["p.4"]);
+    });
+
+    test("18", function () {
+      assertEvaluatesToNodeSet("id(\"t3 t4\")/following::*[1]", ["li", "p.4"]);
+    });
+
+    test("19", function () {
+      assertEvaluatesToNodeSet("id(\"t2 t3 t4\")/following::*[1]", ["p.2", "li", "p.4"]);
+    });
+
+    test("20", function () {
+      assertEvaluatesToNodeSet("id(\"t1 t2 t3 t4\")/following::*[1]", ["li", "p.2", "li", "p.4"]);
+    });
+
+    test("21", function () {
+      assertEvaluatesToNodeSet("id(\"t1 t2 t3 t4\")/preceding::*[1]", ["p.1", "li", "p.3", "li"]);
+    });
+
+    test("22", function () {
+      assertEvaluatesToNodeSet("id(\"t1 t2 t3\")/preceding::*[1]", ["p.1", "li", "p.3"]);
+    });
+
+    test("23", function () {
+      assertEvaluatesToNodeSet("id(\"t1 t2\")/preceding::*[1]", ["p.1", "li"]);
+    });
+
+    test("24", function () {
+      assertEvaluatesToNodeSet("id(\"t1\")/preceding::*[1]", ["p.1"]);
+    });
+
+    test("25", function () {
+      assertEvaluatesToNodeSet("id(\"t2\")/preceding::*[1]", ["li"]);
+    });
+
+    test("26", function () {
+      assertEvaluatesToNodeSet("id(\"t3\")/preceding::*[1]", ["p.3"]);
+    });
+
+    test("27", function () {
+      assertEvaluatesToNodeSet("id(\"t4\")/preceding::*[1]", ["li"]);
+    });
+  });
+});

--- a/test/dom_sibling_test.js
+++ b/test/dom_sibling_test.js
@@ -1,0 +1,92 @@
+"use strict";
+
+var React = require("react");
+
+var Helper = require("./helper");
+
+var Doc = React.createClass({
+  render: function () {
+    return (
+      <html>
+        <head>
+          <title>title</title>
+        </head>
+        <body>
+          <div><span id='first' className='1'></span>foo<span className='2'></span>bar<span className='3'></span>baz<span id='last' className='4'></span></div>
+        </body>
+      </html>
+    );
+  }
+});
+
+var document = Helper.render(<Doc/>);
+
+var assertEvaluatesToNodeSet = Helper.assertEvaluatesToNodeSet.bind(null, document);
+
+suite("XPathReact", function () {
+  suite("sibling", function () {
+    test("00", function () {
+      assertEvaluatesToNodeSet("id(\"first\")/following-sibling::*", ["span.2", "span.3", "span.4"]);
+    });
+
+    test("01", function () {
+      assertEvaluatesToNodeSet("id(\"first\")/following-sibling::node()", ["text(foo)", "span.2", "text(bar)", "span.3", "text(baz)", "span.4"]);
+    });
+
+    test("02", function () {
+      assertEvaluatesToNodeSet("id(\"first\")/following-sibling::*/following-sibling::*", ["span.3", "span.4"]);
+    });
+
+    test("03", function () {
+      assertEvaluatesToNodeSet("id(\"first\")/following-sibling::node()/following-sibling::node()", ["span.2", "text(bar)", "span.3", "text(baz)", "span.4"]);
+    });
+
+    test("04", function () {
+      assertEvaluatesToNodeSet("id(\"first\")/following-sibling::*[1]", ["span.2"]);
+    });
+
+    test("05", function () {
+      assertEvaluatesToNodeSet("id(\"first\")/following-sibling::node()[1]", ["text(foo)"]);
+    });
+
+    test("06", function () {
+      assertEvaluatesToNodeSet("id(\"first\")/following-sibling::*/following-sibling::*[1]", ["span.3", "span.4"]);
+    });
+
+    test("07", function () {
+      assertEvaluatesToNodeSet("id(\"first\")/following-sibling::node()/following-sibling::node()[1]", ["span.2", "text(bar)", "span.3", "text(baz)", "span.4"]);
+    });
+
+    test("08", function () {
+      assertEvaluatesToNodeSet("id(\"last\")/preceding-sibling::*", ["span.1", "span.2", "span.3"]);
+    });
+
+    test("09", function () {
+      assertEvaluatesToNodeSet("id(\"last\")/preceding-sibling::node()", ["span.1", "text(foo)", "span.2", "text(bar)", "span.3", "text(baz)"]);
+    });
+
+    test("10", function () {
+      assertEvaluatesToNodeSet("id(\"last\")/preceding-sibling::*/preceding-sibling::*", ["span.1", "span.2"]);
+    });
+
+    test("11", function () {
+      assertEvaluatesToNodeSet("id(\"last\")/preceding-sibling::node()/preceding-sibling::node()", ["span.1", "text(foo)", "span.2", "text(bar)", "span.3"]);
+    });
+
+    test("12", function () {
+      assertEvaluatesToNodeSet("id(\"last\")/preceding-sibling::*[1]", ["span.3"]);
+    });
+
+    test("13", function () {
+      assertEvaluatesToNodeSet("id(\"last\")/preceding-sibling::node()[1]", ["text(baz)"]);
+    });
+
+    test("14", function () {
+      assertEvaluatesToNodeSet("id(\"last\")/preceding-sibling::*/preceding-sibling::*[1]", ["span.1", "span.2"]);
+    });
+
+    test("15", function () {
+      assertEvaluatesToNodeSet("id(\"last\")/preceding-sibling::node()/preceding-sibling::node()[1]", ["span.1", "text(foo)", "span.2", "text(bar)", "span.3"]);
+    });
+  });
+});

--- a/test/dom_simple_value_test.js
+++ b/test/dom_simple_value_test.js
@@ -1,0 +1,334 @@
+"use strict";
+
+var React = require("react");
+
+var Helper = require("./helper");
+
+var Doc = React.createClass({
+  render: function () {
+    return (
+      <html>
+        <head>
+          <title>Title</title>
+        </head>
+        <body>
+          <div>
+            <span id='a'>hoge</span>
+            <span id='b'>3</span>
+          </div>
+          <ol id='numbers'>
+            <li>1</li>
+            <li>2</li>
+            <li>3</li>
+            <li>4</li>
+            <li>5</li>
+          </ol>
+        </body>
+      </html>
+    );
+  }
+});
+
+var document = Helper.render(<Doc/>);
+
+var DOCUMENT_AS_STRING = "Titlehoge312345";
+
+var assertEvaluatesToNodeSet = Helper.assertEvaluatesToNodeSet.bind(null, document);
+
+var assertEvaluatesToValue = Helper.assertEvaluatesToValue.bind(null, document);
+
+suite("XPathReact", function () {
+  suite("simple value", function () {
+    test("00", function () {
+      assertEvaluatesToValue("local-name(/html)", "html");
+    });
+
+    test("01", function () {
+      assertEvaluatesToValue("count(/)", 1);
+    });
+
+    test("02", function () {
+      assertEvaluatesToValue("count(//li)", 5);
+    });
+
+    test("03", function () {
+      assertEvaluatesToValue("boolean(id('b'))", true);
+    });
+
+    test("04", function () {
+      assertEvaluatesToValue("boolean(/..)", false);
+    });
+
+    test("05", function () {
+      assertEvaluatesToValue("boolean(0)", false);
+    });
+
+    test("06", function () {
+      assertEvaluatesToValue("boolean(NaN)", false);
+    });
+
+    test("07", function () {
+      assertEvaluatesToValue("boolean(1)", true);
+    });
+
+    test("08", function () {
+      assertEvaluatesToValue("boolean(-1)", true);
+    });
+
+    test("09", function () {
+      assertEvaluatesToValue("boolean('')", false);
+    });
+
+    test("10", function () {
+      assertEvaluatesToValue("boolean('Nice boat.')", true);
+    });
+
+    test("11", function () {
+      assertEvaluatesToValue("not(true())", false);
+    });
+
+    test("12", function () {
+      assertEvaluatesToValue("true() and true()", true);
+    });
+
+    test("13", function () {
+      assertEvaluatesToValue("true() or  false()", true);
+    });
+
+    test("14", function () {
+      assertEvaluatesToValue("number(id('b'))", 3);
+    });
+
+    test("15", function () {
+      assertEvaluatesToValue("number('1')", 1);
+    });
+
+    test("16", function () {
+      assertEvaluatesToValue("number('-1')", -1);
+    });
+
+    test("17", function () {
+      assertEvaluatesToValue("number(' 1')", 1);
+    });
+
+    test("18", function () {
+      assertEvaluatesToValue("number(' -1')", -1);
+    });
+
+    test("19", function () {
+      assertEvaluatesToValue("number(true())", 1);
+    });
+
+    test("20", function () {
+      assertEvaluatesToValue("number(false())", 0);
+    });
+
+    test("21", function () {
+      assertEvaluatesToValue("sum(id('numbers')/li)", 15);
+    });
+
+    test("22", function () {
+      assertEvaluatesToValue("1 + 1", 2);
+    });
+
+    test("23", function () {
+      assertEvaluatesToValue("1+1", 2);
+    });
+
+    test("24", function () {
+      assertEvaluatesToValue("1 - 1", 0);
+    });
+
+    test("25", function () {
+      assertEvaluatesToValue("1-1", 0);
+    });
+
+    test("26", function () {
+      assertEvaluatesToValue("string(/ - /)", "NaN");
+    });
+
+    test("27", function () {
+      assertEvaluatesToValue("normalize-space(string())", DOCUMENT_AS_STRING);
+    });
+
+    test("28", function () {
+      assertEvaluatesToValue("normalize-space(string(.))", DOCUMENT_AS_STRING);
+    });
+
+    test("29", function () {
+      assertEvaluatesToValue("normalize-space(string(/))", DOCUMENT_AS_STRING);
+    });
+
+    test("30", function () {
+      assertEvaluatesToValue("normalize-space(string(/html))", DOCUMENT_AS_STRING);
+    });
+
+    test("31", function () {
+      assertEvaluatesToValue("normalize-space(string(//div))", "hoge3");
+    });
+
+    test("32", function () {
+      assertEvaluatesToValue("string(//*//*//*)", "Title");
+    });
+
+    test("33", function () {
+      assertEvaluatesToValue("string(/..)", "");
+    });
+
+    test("34", function () {
+      assertEvaluatesToValue("string(number('Nice boat.'))", "NaN");
+    });
+
+    test("35", function () {
+      assertEvaluatesToValue("string(1 div 0)", "Infinity");
+    });
+
+    test("36", function () {
+      assertEvaluatesToValue("string(1 div -0)", "-Infinity");
+    });
+
+    test("37", function () {
+      assertEvaluatesToValue("string(0)", "0");
+    });
+
+    test("38", function () {
+      assertEvaluatesToValue("string(-0)", "0");
+    });
+
+    test("39", function () {
+      assertEvaluatesToValue("string(1)", "1");
+    });
+
+    test("40", function () {
+      assertEvaluatesToValue("string(-1)", "-1");
+    });
+
+    test("41", function () {
+      assertEvaluatesToValue("string(true())", "true");
+    });
+
+    test("42", function () {
+      assertEvaluatesToValue("string(false())", "false");
+    });
+
+    test("43", function () {
+      assertEvaluatesToValue("string-length('')", 0);
+    });
+
+    test("44", function () {
+      assertEvaluatesToValue("string-length('a')", 1);
+    });
+
+    test("45", function () {
+      assertEvaluatesToValue("contains('abcdefg', 'def')", true);
+    });
+
+    test("46", function () {
+      assertEvaluatesToValue("contains('abcdefg', 'zzz')", false);
+    });
+
+    test("47", function () {
+      assertEvaluatesToValue("starts-with('abcdefg', 'abc')", true);
+    });
+
+    test("48", function () {
+      assertEvaluatesToValue("starts-with('abcdefg', 'def')", false);
+    });
+
+    test("49", function () {
+      assertEvaluatesToValue("concat('abc', 'def')", "abcdef");
+    });
+
+    test("50", function () {
+      assertEvaluatesToValue("concat('abc', 'def', 'ghi')", "abcdefghi");
+    });
+
+    test("51", function () {
+      assertEvaluatesToValue("concat('abc', 'def', 'ghi', 'jkl')", "abcdefghijkl");
+    });
+
+    test("52", function () {
+      assertEvaluatesToValue("translate('bar','abc','ABC')", "BAr");
+    });
+
+    test("53", function () {
+      assertEvaluatesToValue("translate('--aaa--','abc-','ABC')", "AAA");
+    });
+
+    test("54", function () {
+      assertEvaluatesToValue("substring('12345', 2, 3)", "234");
+    });
+
+    test("55", function () {
+      assertEvaluatesToValue("substring('12345', 2)", "2345");
+    });
+
+    test("56", function () {
+      assertEvaluatesToValue("substring('12345', 1.5, 2.6)", "234");
+    });
+
+    test("57", function () {
+      assertEvaluatesToValue("substring('12345', 0, 3)", "12");
+    });
+
+    test("58", function () {
+      assertEvaluatesToValue("substring('12345', 0 div 0, 3)", "");
+    });
+
+    test("59", function () {
+      assertEvaluatesToValue("substring('12345', 1, 0 div 0)", "");
+    });
+
+    test("60", function () {
+      assertEvaluatesToValue("substring('12345', -42, 1 div 0)", "12345");
+    });
+
+    test("61", function () {
+      assertEvaluatesToValue("substring('12345', -1 div 0, 1 div 0)", "");
+    });
+
+    test("62", function () {
+      assertEvaluatesToValue("substring-after('1999/04/01','/')", "04/01");
+    });
+
+    test("63", function () {
+      assertEvaluatesToValue("substring-after('1999/04/01','19')", "99/04/01");
+    });
+
+    test("64", function () {
+      assertEvaluatesToValue("substring-before('1999/04/01','/')", "1999");
+    });
+
+    test("65", function () {
+      assertEvaluatesToValue("normalize-space(id('numbers')/li) = '1'", true);
+    });
+
+    test("66", function () {
+      assertEvaluatesToValue("id('numbers')/li = id('numbers')/li", true);
+    });
+
+    test("67", function () {
+      assertEvaluatesToValue("'' = false()", true);
+    });
+
+    test("68", function () {
+      assertEvaluatesToValue("false() = ''", true);
+    });
+
+    test("69", function () {
+      assertEvaluatesToValue("'1' = 1", true);
+    });
+
+    test("70", function () {
+      assertEvaluatesToValue("1 = '1'", true);
+    });
+
+    test("71", function () {
+      assertEvaluatesToValue("'1' = '1'", true);
+    });
+
+    test("72", function () {
+      assertEvaluatesToNodeSet("html-html", []);
+    });
+  });
+});

--- a/test/dom_sort_and_merge_test.js
+++ b/test/dom_sort_and_merge_test.js
@@ -1,0 +1,91 @@
+"use strict";
+
+var React = require("react");
+var ReactDom = require("react-dom");
+
+var Helper = require("./helper");
+
+var jsdom = require("jsdom");
+
+global.document = jsdom.jsdom("");
+global.window = document.defaultView;
+global.navigator = window.navigator;
+
+var Doc = React.createClass({
+  render: function () {
+    return (
+      <div>
+        <ul id='container'>
+          <li id='li-1'></li>
+          <li id='li-2'></li>
+          <li id='li-3'></li>
+          <li id='li-4'></li>
+        </ul>
+        <ul id='container-0'>
+          <li id='li-5'></li>
+          <li id='li-6'></li>
+          <li id='li-7'></li>
+          <li id='li-8'></li>
+        </ul>
+      </div>
+    );
+  }
+});
+
+var div = document.createElement("div");
+document.body.appendChild(div);
+var output = ReactDom.render(<Doc />, div);
+
+var assertEvaluatesToNodeSet = Helper.assertEvaluatesToNodeSet.bind(null, output);
+
+suite("XPathReact", function () {
+  suite("sort and merge", function () {
+    test("00", function () {
+      assertEvaluatesToNodeSet("id('container')/*[1]", ["li#li-1"]);
+    });
+
+    test("01", function () {
+      assertEvaluatesToNodeSet("id('container')/*[2]", ["li#li-2"]);
+    });
+
+    test("02", function () {
+      assertEvaluatesToNodeSet("id('container')/*[3]", ["li#li-3"]);
+    });
+
+    test("03", function () {
+      assertEvaluatesToNodeSet("id('container')/*[4]", ["li#li-4"]);
+    });
+
+    test("04", function () {
+      assertEvaluatesToNodeSet("id('container')/*[3] | id('container')/*[4] | id('container')/*[2] | id('container')/*[1]", ["li#li-1", "li#li-2", "li#li-3", "li#li-4"]);
+    });
+
+    test("05", function () {
+      assertEvaluatesToNodeSet("id('container')/*[4] | id('container')/*[2] | id('container')/*[4] | id('container')/*[3]", ["li#li-2", "li#li-3", "li#li-4"]);
+    });
+
+    test("06", function () {
+      assertEvaluatesToNodeSet("id('li-1 li-2 li-3 li-4')", ["li#li-1", "li#li-2", "li#li-3", "li#li-4"]);
+    });
+
+    test("07", function () {
+      assertEvaluatesToNodeSet("id('li-4 li-3 li-2 li-1')", ["li#li-1", "li#li-2", "li#li-3", "li#li-4"]);
+    });
+
+    test("08", function () {
+      assertEvaluatesToNodeSet("id('li-2 li-2 li-1 li-1')", ["li#li-1", "li#li-2"]);
+    });
+
+    test("09", function () {
+      assertEvaluatesToNodeSet("id('container')/* | id('container-0')/*", ["li#li-1", "li#li-2", "li#li-3", "li#li-4", "li#li-5", "li#li-6", "li#li-7", "li#li-8"]);
+    });
+
+    test("10", function () {
+      assertEvaluatesToNodeSet("id('container-0')/* | id('container')/*", ["li#li-1", "li#li-2", "li#li-3", "li#li-4", "li#li-5", "li#li-6", "li#li-7", "li#li-8"]);
+    });
+
+    test("11", function () {
+      assertEvaluatesToNodeSet("id('container-0')/* | id('container')/* | id('container-0')/*", ["li#li-1", "li#li-2", "li#li-3", "li#li-4", "li#li-5", "li#li-6", "li#li-7", "li#li-8"]);
+    });
+  });
+});

--- a/test/dom_test.js
+++ b/test/dom_test.js
@@ -1,0 +1,50 @@
+"use strict";
+
+var Assert = require("assert");
+
+var XPathUtils = require("../utils");
+
+var Helper = require("./helper");
+
+var React = require("react");
+var ReactDom = require('react-dom');
+var ReactTestUtils = require("react-addons-test-utils");
+
+var jsdom = require('jsdom');
+
+global.document = jsdom.jsdom('');
+global.window = document.defaultView;
+global.navigator = window.navigator;
+
+var A = React.createClass({
+  render: function () {
+    return <div>{ this.props.content }</div>;
+  }
+});
+
+var B = React.createClass({
+  render: function () {
+    return <div>label: <input type='text' name='test'></input></div>;
+  }
+});
+
+describe("XPathReact", function () {
+  describe("Dom", function () {
+    it("should find B in rendered component", function () {
+      
+      var div = document.createElement("div");
+      document.body.appendChild(div);
+
+      var el = React.createElement(A, { content: React.createElement(B) });
+      ReactDom.render(el, div);
+      
+      var p = XPathUtils.find(XPathUtils.findReactRoot(), ".//B");
+      Assert.equal(p.type, B);
+      var p2 = XPathUtils.find(XPathUtils.findReactRoot(), './/input[@type="text"]');
+      Assert.equal(p2.tagName, 'INPUT');
+      Assert.equal(p2.type, 'text');
+      Assert.equal(p2.name, 'test');
+    });
+
+  });
+});

--- a/test/dom_test.js
+++ b/test/dom_test.js
@@ -79,7 +79,31 @@ describe("XPathReact", function () {
       Assert.equal(p.tagName, "INPUT");
       Assert.equal(p.type, "text");
       Assert.equal(p.name, "test");
+
+      var p2 = XPathUtils.find(".//B//*[@type='text']", output);
+      Assert.equal(p, p2);
     });
+
+    it("should not find B in rendered component (demonstrate difference between evaluation on component tree and elements))", function () {
+      
+      initDOM();
+
+      var div = document.createElement("div");
+      document.body.appendChild(div);
+
+      var el = React.createElement(A, { content: React.createElement(B) });
+      var output = ReactDom.render(el, div)._reactInternalInstance._currentElement;
+
+      var p = XPathUtils.find(".//input[@type='text']", output);
+      Assert.equal(!!p, false);
+
+      var p2 = XPathUtils.find(".//B//*[@type='text']", output);
+      Assert.equal(!!p2, false);
+
+      var p3 = XPathUtils.find(".//A", output);
+      Assert.equal(p3.type, A);
+    });
+
 
   });
 });

--- a/test/dom_test.js
+++ b/test/dom_test.js
@@ -15,7 +15,7 @@ function initDOM() {
   global.navigator = window.navigator;
 }
 
-if (React.version.charAt(0) !== '0') {
+if (React.version.charAt(0) !== "0") {
 
   var Wrapper = React.createClass({
     render: function () {

--- a/test/dom_test.js
+++ b/test/dom_test.js
@@ -12,9 +12,11 @@ var ReactTestUtils = require("react-addons-test-utils");
 
 var jsdom = require('jsdom');
 
-global.document = jsdom.jsdom('');
-global.window = document.defaultView;
-global.navigator = window.navigator;
+function initDOM() {
+  global.document = jsdom.jsdom('');
+  global.window = document.defaultView;
+  global.navigator = window.navigator;
+}
 
 var A = React.createClass({
   render: function () {
@@ -24,7 +26,7 @@ var A = React.createClass({
 
 var B = React.createClass({
   render: function () {
-    return <div>label: <input type='text' name='test'></input></div>;
+    return <div><span>label:</span> <input type='text' name='test'></input></div>;
   }
 });
 
@@ -32,6 +34,8 @@ describe("XPathReact", function () {
   describe("Dom", function () {
     it("should find B in rendered component", function () {
       
+      initDOM();
+
       var div = document.createElement("div");
       document.body.appendChild(div);
 
@@ -40,10 +44,37 @@ describe("XPathReact", function () {
       
       var p = XPathUtils.find(XPathUtils.findReactRoot(), ".//B");
       Assert.equal(p.type, B);
-      var p2 = XPathUtils.find(XPathUtils.findReactRoot(), './/input[@type="text"]');
-      Assert.equal(p2.tagName, 'INPUT');
-      Assert.equal(p2.type, 'text');
-      Assert.equal(p2.name, 'test');
+    });
+
+    it("should find B with key in rendered component", function () {
+      
+      initDOM();
+
+      var div = document.createElement("div");
+      document.body.appendChild(div);
+
+      var eldiv = <div><B key="1" /><B key="2" /><B key="3" /></div>
+      var el = React.createElement(A, { content: eldiv });
+      ReactDom.render(el, div);
+      
+      var p = XPathUtils.find(XPathUtils.findReactRoot(), './/B[@key="1"]');
+      Assert.equal(p.type, B);
+    });
+
+    it("should find input in rendered component", function () {
+      
+      initDOM();
+
+      var div = document.createElement("div");
+      document.body.appendChild(div);
+
+      var el = React.createElement(A, { content: React.createElement(B) });
+      ReactDom.render(el, div);
+      
+      var p = XPathUtils.find(XPathUtils.findReactRoot(), './/input[@type="text"]');
+      Assert.equal(p.tagName, 'INPUT');
+      Assert.equal(p.type, 'text');
+      Assert.equal(p.name, 'test');
     });
 
   });

--- a/test/dom_test.js
+++ b/test/dom_test.js
@@ -29,7 +29,7 @@ var A = React.createClass({
 
 var B = React.createClass({
   render: function () {
-    return <div><span>{this.props.btag || "label"}:</span> <input type='text' name='test'></input></div>;
+    return <div><span>{this.props.btag || "label"}:</span> <input type='text' name='test' /></div>;
   }
 });
 

--- a/test/dom_test.js
+++ b/test/dom_test.js
@@ -54,7 +54,7 @@ describe("XPathReact", function () {
       var el = React.createElement(A, { content: eldiv });
       ReactDom.render(el, div);
       
-      var p = XPathUtils.find(XPathUtils.findReactRoot(), ".//B[@key='1']');
+      var p = XPathUtils.find(XPathUtils.findReactRoot(), ".//B[@key='1']");
       Assert.equal(p.type, B);
     });
 
@@ -68,7 +68,7 @@ describe("XPathReact", function () {
       var el = React.createElement(A, { content: React.createElement(B) });
       ReactDom.render(el, div);
       
-      var p = XPathUtils.find(XPathUtils.findReactRoot(), ".//input[@type='text']);
+      var p = XPathUtils.find(XPathUtils.findReactRoot(), ".//input[@type='text']");
       Assert.equal(p.tagName, "INPUT");
       Assert.equal(p.type, "text");
       Assert.equal(p.name, "test");

--- a/test/dom_test.js
+++ b/test/dom_test.js
@@ -15,74 +15,71 @@ function initDOM() {
   global.navigator = window.navigator;
 }
 
-if (React.version.charAt(0) !== "0") {
+var Wrapper = React.createClass({
+  render: function () {
+    return React.Children.only(this.props.children);
+  }
+});
 
-  var Wrapper = React.createClass({
-    render: function () {
-      return React.Children.only(this.props.children);
-    }
-  });
+var A = React.createClass({
+  render: function () {
+    return <div>{ this.props.content }</div>;
+  }
+});
 
-  var A = React.createClass({
-    render: function () {
-      return <div>{ this.props.content }</div>;
-    }
-  });
+var B = React.createClass({
+  render: function () {
+    return <div><span>label:</span> <input type='text' name='test'></input></div>;
+  }
+});
 
-  var B = React.createClass({
-    render: function () {
-      return <div><span>label:</span> <input type='text' name='test'></input></div>;
-    }
-  });
+describe("XPathReact", function () {
+  describe("Dom", function () {
+    it("should find B in rendered component", function () {
+      
+      initDOM();
 
-  describe("XPathReact", function () {
-    describe("Dom", function () {
-      it("should find B in rendered component", function () {
-        
-        initDOM();
+      var div = document.createElement("div");
+      document.body.appendChild(div);
 
-        var div = document.createElement("div");
-        document.body.appendChild(div);
-
-        var elb = <B />;
-        var el = <Wrapper><A content={elb} /></Wrapper>;
-        ReactDom.render(el, div);
-        
-        var p = XPathUtils.find(XPathUtils.findReactRoot(), ".//B");
-        Assert.equal(p.type, B);
-      });
-
-      it("should find B with key in rendered component", function () {
-        
-        initDOM();
-
-        var div = document.createElement("div");
-        document.body.appendChild(div);
-
-        var eldiv = <div><B key="1" /><B key="2" /><B key="3" /></div>;
-        var el = React.createElement(A, { content: eldiv });
-        ReactDom.render(el, div);
-        
-        var p = XPathUtils.find(XPathUtils.findReactRoot(), ".//B[@key='1']");
-        Assert.equal(p.type, B);
-      });
-
-      it("should find input in rendered component", function () {
-        
-        initDOM();
-
-        var div = document.createElement("div");
-        document.body.appendChild(div);
-
-        var el = React.createElement(A, { content: React.createElement(B) });
-        ReactDom.render(el, div);
-        
-        var p = XPathUtils.find(XPathUtils.findReactRoot(), ".//input[@type='text']");
-        Assert.equal(p.tagName, "INPUT");
-        Assert.equal(p.type, "text");
-        Assert.equal(p.name, "test");
-      });
-
+      var elb = <B />;
+      var el = <Wrapper><A content={elb} /></Wrapper>;
+      var output = ReactDom.render(el, div);
+      
+      var p = XPathUtils.find(output, ".//B");
+      Assert.equal(p.type, B);
     });
+
+    it("should find B with key in rendered component", function () {
+      
+      initDOM();
+
+      var div = document.createElement("div");
+      document.body.appendChild(div);
+
+      var eldiv = <div><B key="1" /><B key="2" /><B key="3" /></div>;
+      var el = React.createElement(A, { content: eldiv });
+      var output = ReactDom.render(el, div);
+      
+      var p = XPathUtils.find(output, ".//B[@key='1']");
+      Assert.equal(p.type, B);
+    });
+
+    it("should find input in rendered component", function () {
+      
+      initDOM();
+
+      var div = document.createElement("div");
+      document.body.appendChild(div);
+
+      var el = React.createElement(A, { content: React.createElement(B) });
+      var output = ReactDom.render(el, div);
+      
+      var p = XPathUtils.find(output, ".//input[@type='text']");
+      Assert.equal(p.tagName, "INPUT");
+      Assert.equal(p.type, "text");
+      Assert.equal(p.name, "test");
+    });
+
   });
-}
+});

--- a/test/dom_test.js
+++ b/test/dom_test.js
@@ -4,16 +4,13 @@ var Assert = require("assert");
 
 var XPathUtils = require("../utils");
 
-var Helper = require("./helper");
-
 var React = require("react");
-var ReactDom = require('react-dom');
-var ReactTestUtils = require("react-addons-test-utils");
+var ReactDom = require("react-dom");
 
-var jsdom = require('jsdom');
+var jsdom = require("jsdom");
 
 function initDOM() {
-  global.document = jsdom.jsdom('');
+  global.document = jsdom.jsdom("");
   global.window = document.defaultView;
   global.navigator = window.navigator;
 }
@@ -57,7 +54,7 @@ describe("XPathReact", function () {
       var el = React.createElement(A, { content: eldiv });
       ReactDom.render(el, div);
       
-      var p = XPathUtils.find(XPathUtils.findReactRoot(), './/B[@key="1"]');
+      var p = XPathUtils.find(XPathUtils.findReactRoot(), ".//B[@key='1']');
       Assert.equal(p.type, B);
     });
 
@@ -71,10 +68,10 @@ describe("XPathReact", function () {
       var el = React.createElement(A, { content: React.createElement(B) });
       ReactDom.render(el, div);
       
-      var p = XPathUtils.find(XPathUtils.findReactRoot(), './/input[@type="text"]');
-      Assert.equal(p.tagName, 'INPUT');
-      Assert.equal(p.type, 'text');
-      Assert.equal(p.name, 'test');
+      var p = XPathUtils.find(XPathUtils.findReactRoot(), ".//input[@type='text']);
+      Assert.equal(p.tagName, "INPUT");
+      Assert.equal(p.type, "text");
+      Assert.equal(p.name, "test");
     });
 
   });

--- a/test/dom_test.js
+++ b/test/dom_test.js
@@ -53,7 +53,7 @@ describe("XPathReact", function () {
       var div = document.createElement("div");
       document.body.appendChild(div);
 
-      var eldiv = <div><B key="1" /><B key="2" /><B key="3" /></div>
+      var eldiv = <div><B key="1" /><B key="2" /><B key="3" /></div>;
       var el = React.createElement(A, { content: eldiv });
       ReactDom.render(el, div);
       

--- a/test/dom_test.js
+++ b/test/dom_test.js
@@ -15,64 +15,74 @@ function initDOM() {
   global.navigator = window.navigator;
 }
 
-var A = React.createClass({
-  render: function () {
-    return <div>{ this.props.content }</div>;
-  }
-});
+if (React.version.charAt(0) !== '0') {
 
-var B = React.createClass({
-  render: function () {
-    return <div><span>label:</span> <input type='text' name='test'></input></div>;
-  }
-});
-
-describe("XPathReact", function () {
-  describe("Dom", function () {
-    it("should find B in rendered component", function () {
-      
-      initDOM();
-
-      var div = document.createElement("div");
-      document.body.appendChild(div);
-
-      var el = React.createElement(A, { content: React.createElement(B) });
-      ReactDom.render(el, div);
-      
-      var p = XPathUtils.find(XPathUtils.findReactRoot(), ".//B");
-      Assert.equal(p.type, B);
-    });
-
-    it("should find B with key in rendered component", function () {
-      
-      initDOM();
-
-      var div = document.createElement("div");
-      document.body.appendChild(div);
-
-      var eldiv = <div><B key="1" /><B key="2" /><B key="3" /></div>;
-      var el = React.createElement(A, { content: eldiv });
-      ReactDom.render(el, div);
-      
-      var p = XPathUtils.find(XPathUtils.findReactRoot(), ".//B[@key='1']");
-      Assert.equal(p.type, B);
-    });
-
-    it("should find input in rendered component", function () {
-      
-      initDOM();
-
-      var div = document.createElement("div");
-      document.body.appendChild(div);
-
-      var el = React.createElement(A, { content: React.createElement(B) });
-      ReactDom.render(el, div);
-      
-      var p = XPathUtils.find(XPathUtils.findReactRoot(), ".//input[@type='text']");
-      Assert.equal(p.tagName, "INPUT");
-      Assert.equal(p.type, "text");
-      Assert.equal(p.name, "test");
-    });
-
+  var Wrapper = React.createClass({
+    render: function () {
+      return React.Children.only(this.props.children);
+    }
   });
-});
+
+  var A = React.createClass({
+    render: function () {
+      return <div>{ this.props.content }</div>;
+    }
+  });
+
+  var B = React.createClass({
+    render: function () {
+      return <div><span>label:</span> <input type='text' name='test'></input></div>;
+    }
+  });
+
+  describe("XPathReact", function () {
+    describe("Dom", function () {
+      it("should find B in rendered component", function () {
+        
+        initDOM();
+
+        var div = document.createElement("div");
+        document.body.appendChild(div);
+
+        var elb = <B />;
+        var el = <Wrapper><A content={elb} /></Wrapper>;
+        ReactDom.render(el, div);
+        
+        var p = XPathUtils.find(XPathUtils.findReactRoot(), ".//B");
+        Assert.equal(p.type, B);
+      });
+
+      it("should find B with key in rendered component", function () {
+        
+        initDOM();
+
+        var div = document.createElement("div");
+        document.body.appendChild(div);
+
+        var eldiv = <div><B key="1" /><B key="2" /><B key="3" /></div>;
+        var el = React.createElement(A, { content: eldiv });
+        ReactDom.render(el, div);
+        
+        var p = XPathUtils.find(XPathUtils.findReactRoot(), ".//B[@key='1']");
+        Assert.equal(p.type, B);
+      });
+
+      it("should find input in rendered component", function () {
+        
+        initDOM();
+
+        var div = document.createElement("div");
+        document.body.appendChild(div);
+
+        var el = React.createElement(A, { content: React.createElement(B) });
+        ReactDom.render(el, div);
+        
+        var p = XPathUtils.find(XPathUtils.findReactRoot(), ".//input[@type='text']");
+        Assert.equal(p.tagName, "INPUT");
+        Assert.equal(p.type, "text");
+        Assert.equal(p.name, "test");
+      });
+
+    });
+  });
+}

--- a/test/dom_test.js
+++ b/test/dom_test.js
@@ -46,7 +46,7 @@ describe("XPathReact", function () {
       var el = <Wrapper><A content={elb} /></Wrapper>;
       var output = ReactDom.render(el, div);
       
-      var p = XPathUtils.find(output, ".//B");
+      var p = XPathUtils.find(".//B", output);
       Assert.equal(p.type, B);
     });
 
@@ -61,7 +61,7 @@ describe("XPathReact", function () {
       var el = React.createElement(A, { content: eldiv });
       var output = ReactDom.render(el, div);
       
-      var p = XPathUtils.find(output, ".//B[@key='1']");
+      var p = XPathUtils.find(".//B[@key='1']", output);
       Assert.equal(p.type, B);
     });
 
@@ -75,7 +75,7 @@ describe("XPathReact", function () {
       var el = React.createElement(A, { content: React.createElement(B) });
       var output = ReactDom.render(el, div);
       
-      var p = XPathUtils.find(output, ".//input[@type='text']");
+      var p = XPathUtils.find(".//input[@type='text']", output);
       Assert.equal(p.tagName, "INPUT");
       Assert.equal(p.type, "text");
       Assert.equal(p.name, "test");

--- a/test/dom_test.js
+++ b/test/dom_test.js
@@ -23,13 +23,13 @@ var Wrapper = React.createClass({
 
 var A = React.createClass({
   render: function () {
-    return <div>{ this.props.content }</div>;
+    return <div><B btag={this.props.tag} /></div>;
   }
 });
 
 var B = React.createClass({
   render: function () {
-    return <div><span>label:</span> <input type='text' name='test'></input></div>;
+    return <div><span>{this.props.btag || "label"}:</span> <input type='text' name='test'></input></div>;
   }
 });
 
@@ -42,12 +42,13 @@ describe("XPathReact", function () {
       var div = document.createElement("div");
       document.body.appendChild(div);
 
-      var elb = <B />;
-      var el = <Wrapper><A content={elb} /></Wrapper>;
-      var output = ReactDom.render(el, div);
+      var output = ReactDom.render(<Wrapper><A tag="tag" /></Wrapper>, div);
       
       var p = XPathUtils.find(".//B", output);
       Assert.equal(p.type, B);
+
+      var p2 = XPathUtils.find(".//*[@btag]", output);
+      Assert.equal(p2, p);
     });
 
     it("should find B with key in rendered component", function () {
@@ -57,12 +58,11 @@ describe("XPathReact", function () {
       var div = document.createElement("div");
       document.body.appendChild(div);
 
-      var eldiv = <div><B key="1" /><B key="2" /><B key="3" /></div>;
-      var el = React.createElement(A, { content: eldiv });
-      var output = ReactDom.render(el, div);
+      var output = ReactDom.render(<Wrapper><div><B key="1" /><B key="2" test="2" /><B key="3" /></div></Wrapper>, div);
       
-      var p = XPathUtils.find(".//B[@key='1']", output);
+      var p = XPathUtils.find(".//B[@key='2']", output);
       Assert.equal(p.type, B);
+      Assert.equal(p.props.test, "2");
     });
 
     it("should find input in rendered component", function () {
@@ -72,16 +72,15 @@ describe("XPathReact", function () {
       var div = document.createElement("div");
       document.body.appendChild(div);
 
-      var el = React.createElement(A, { content: React.createElement(B) });
-      var output = ReactDom.render(el, div);
+      var output = ReactDom.render(<A />, div);
       
-      var p = XPathUtils.find(".//input[@type='text']", output);
+      var p = XPathUtils.find(".//input", output);
       Assert.equal(p.tagName, "INPUT");
       Assert.equal(p.type, "text");
       Assert.equal(p.name, "test");
 
       var p2 = XPathUtils.find(".//B//*[@type='text']", output);
-      Assert.equal(p, p2);
+      Assert.equal(p2, p);
     });
 
     it("should not find B in rendered component (demonstrate difference between evaluation on component tree and elements))", function () {
@@ -91,10 +90,9 @@ describe("XPathReact", function () {
       var div = document.createElement("div");
       document.body.appendChild(div);
 
-      var el = React.createElement(A, { content: React.createElement(B) });
-      var output = ReactDom.render(el, div)._reactInternalInstance._currentElement;
+      var output = ReactDom.render(<A />, div)._reactInternalInstance._currentElement;
 
-      var p = XPathUtils.find(".//input[@type='text']", output);
+      var p = XPathUtils.find(".//input", output);
       Assert.equal(!!p, false);
 
       var p2 = XPathUtils.find(".//B//*[@type='text']", output);

--- a/test/double_slash_and_descendant_test.js
+++ b/test/double_slash_and_descendant_test.js
@@ -4,32 +4,38 @@ var React = require("react");
 
 var Helper = require("./helper");
 
-var document = (
-  <html>
-    <head>
-      <title>Title</title>
-    </head>
-    <body>
-      <div id='parent'>
-        <div id='child-1'>
-          <div id='grand-child-1-1'></div>
-          <p>dust</p>
-          <div id='grand-child-1-2'></div>
-          <p>dust</p>
-          <div id='grand-child-1-3'></div>
-        </div>
-        <p>dust</p>
-        <div id='child-2'>
-          <div id='grand-child-2-1'></div>
-          <p>dust</p>
-          <div id='grand-child-2-2'></div>
-          <p>dust</p>
-          <div id='grand-child-2-3'></div>
-        </div>
-      </div>
-    </body>
-  </html>
-);
+var Doc = React.createClass({
+  render: function () {
+    return (
+      <html>
+        <head>
+          <title>Title</title>
+        </head>
+        <body>
+          <div id='parent'>
+            <div id='child-1'>
+              <div id='grand-child-1-1'></div>
+              <p>dust</p>
+              <div id='grand-child-1-2'></div>
+              <p>dust</p>
+              <div id='grand-child-1-3'></div>
+            </div>
+            <p>dust</p>
+            <div id='child-2'>
+              <div id='grand-child-2-1'></div>
+              <p>dust</p>
+              <div id='grand-child-2-2'></div>
+              <p>dust</p>
+              <div id='grand-child-2-3'></div>
+            </div>
+          </div>
+        </body>
+      </html>
+    );
+  }
+});
+
+var document = Helper.render(<Doc/>);
 
 var assertEvaluatesToNodeSet = Helper.assertEvaluatesToNodeSet.bind(null, document);
 

--- a/test/element_had_length_property_test.js
+++ b/test/element_had_length_property_test.js
@@ -4,32 +4,38 @@ var React = require("react");
 
 var Helper = require("./helper");
 
-var document = (
-  <html>
-    <head>
-      <title>title</title>
-    </head>
-    <body>
-      <select id='target'>
-        <option>foo</option>
-        <option>bar</option>
-        <option>baz</option>
-      </select>
-      <div>
-        <select name='target2' id='a'>
-          <option>foo</option>
-          <option>bar</option>
-          <option>baz</option>
-        </select>
-        <select name='target2' id='b'>
-          <option>foo</option>
-          <option>bar</option>
-          <option>baz</option>
-        </select>
-      </div>
-    </body>
-  </html>
-);
+var Doc = React.createClass({
+  render: function () {
+    return (
+      <html>
+        <head>
+          <title>title</title>
+        </head>
+        <body>
+          <select id='target'>
+            <option>foo</option>
+            <option>bar</option>
+            <option>baz</option>
+          </select>
+          <div>
+            <select name='target2' id='a'>
+              <option>foo</option>
+              <option>bar</option>
+              <option>baz</option>
+            </select>
+            <select name='target2' id='b'>
+              <option>foo</option>
+              <option>bar</option>
+              <option>baz</option>
+            </select>
+          </div>
+        </body>
+      </html>
+    );
+  }
+});
+
+var document = Helper.render(<Doc/>);
 
 var assertEvaluatesToNodeSet = Helper.assertEvaluatesToNodeSet.bind(null, document);
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -14,7 +14,7 @@ module.exports = {
   render: function(el) {
     var shallowRenderer = ReactTestUtils.createRenderer();
     shallowRenderer.render(el);
-    return shallowRenderer.getRenderOutput()
+    return shallowRenderer.getRenderOutput();
   },
 
   assertEvaluatesToNodeSet: function (contextNode, expression, nodes) {

--- a/test/helper.js
+++ b/test/helper.js
@@ -19,33 +19,33 @@ module.exports = {
 
   assertEvaluatesToNodeSet: function (contextNode, expression, nodes) {
     var result = XPathEvaluator.evaluate(expression, contextNode, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE);
-
     var match;
 
     for (var i = 0; i < result.snapshotLength; i++) {
-      if (result.snapshotItem(i).type) {
+      if (result.snapshotItem(i).type || result.snapshotItem(i).tagName) {
         match = nodes[i].match(/(\w+)(?:#([^.]+))?(?:\.([\w\d-]+))?/);
 
-        var tagName = match[1],
-            idName = match[2],
-            className = match[3];
+        var tagName = match[1];
+        var idName = match[2];
+        var className = match[3];
 
         if (tagName) {
-          assert.equal(result.snapshotItem(i).type, tagName);
+          assert.equal(result.snapshotItem(i).tagName && result.snapshotItem(i).tagName.toLowerCase() 
+                       || result.snapshotItem(i).type && (result.snapshotItem(i).type.displayName || result.snapshotItem(i).type.name || result.snapshotItem(i).type), 
+                       tagName);
         }
-
         if (idName) {
-          assert.equal(result.snapshotItem(i).props.id, idName);
+          assert.equal(result.snapshotItem(i).id || result.snapshotItem(i).props && result.snapshotItem(i).props.id, idName);
+        }
+        if (className) {
+          assert.equal(result.snapshotItem(i).className || result.snapshotItem(i).props && result.snapshotItem(i).props.className, className);
         }
 
-        if (className) {
-          assert.equal(result.snapshotItem(i).props.className, className);
-        }
       } else {
         match = nodes[i].match(/^(\w+)(?:\(([^\)]*)\))?$/);
 
-        var nodeType = match[1],
-            nodeValue = match[2];
+        var nodeType = match[1];
+        var nodeValue = match[2];
 
         if (nodeType !== "text") {
           throw new Error("Unable to make assertions about anything other than text nodes");
@@ -60,7 +60,6 @@ module.exports = {
 
   assertEvaluatesToValue: function (contextNode, expression, value) {
     var result = XPathEvaluator.evaluate(expression, contextNode, null, XPathResult.ANY_TYPE);
-
     switch (result.resultType) {
       case XPathResult.NUMBER_TYPE:
         assert.equal(value, result.numberValue);

--- a/test/helper.js
+++ b/test/helper.js
@@ -5,12 +5,17 @@
 "use strict";
 
 var assert = require("assert");
-
-var XPathEvaluator = require("../register");
+var ReactTestUtils = require("react-addons-test-utils");
+var XPathEvaluator = require("../index");
 
 var XPathResult = XPathEvaluator.XPathResult;
 
 module.exports = {
+  render: function(el) {
+    var shallowRenderer = ReactTestUtils.createRenderer();
+    return shallowRenderer.render(el);
+  },
+
   assertEvaluatesToNodeSet: function (contextNode, expression, nodes) {
     var result = XPathEvaluator.evaluate(expression, contextNode, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE);
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -13,7 +13,8 @@ var XPathResult = XPathEvaluator.XPathResult;
 module.exports = {
   render: function(el) {
     var shallowRenderer = ReactTestUtils.createRenderer();
-    return shallowRenderer.render(el);
+    shallowRenderer.render(el);
+    return shallowRenderer.getRenderOutput()
   },
 
   assertEvaluatesToNodeSet: function (contextNode, expression, nodes) {

--- a/test/id_test.js
+++ b/test/id_test.js
@@ -4,15 +4,21 @@ var React = require("react");
 
 var Helper = require("./helper");
 
-var document = (
-  <html>
-    <body>
-      <div id='dupeid'>My id is dupeid</div>
-      <div id='dupeid'>My id is also dupeid</div>
-      <div id='uniqueid'>My id is uniqueid</div>
-    </body>
-  </html>
-);
+var Doc = React.createClass({
+  render: function () {
+    return (
+      <html>
+        <body>
+          <div id='dupeid'>My id is dupeid</div>
+          <div id='dupeid'>My id is also dupeid</div>
+          <div id='uniqueid'>My id is uniqueid</div>
+        </body>
+      </html>
+    );
+  }
+});
+
+var document = Helper.render(<Doc/>);
 
 var assertEvaluatesToNodeSet = Helper.assertEvaluatesToNodeSet.bind(null, document);
 

--- a/test/inline_svg_test.js
+++ b/test/inline_svg_test.js
@@ -4,17 +4,23 @@ var React = require("react");
 
 var Helper = require("./helper");
 
-var document = (
-  <html>
-    <body>
-      <svg id='svg' xmlns='http://www.w3.org/2000/svg' version='1.1' viewBox='0 0 1000 50'>
-        <rect id='rect' fill='red' stroke='none' height='12' width='12' y='20' x='100'></rect>
-        <text id='text' fill='black' font-size='12' font-family='Arial' y='30' x='115'>Apple</text>
-        <path id='path' d='M 200 26 L 600 26' stroke='red' stroke-width='1em'/>
-      </svg>
-    </body>
-  </html>
-);
+var Doc = React.createClass({
+  render: function () {
+    return (
+      <html>
+        <body>
+          <svg id='svg' xmlns='http://www.w3.org/2000/svg' version='1.1' viewBox='0 0 1000 50'>
+            <rect id='rect' fill='red' stroke='none' height='12' width='12' y='20' x='100'></rect>
+            <text id='text' fill='black' font-size='12' font-family='Arial' y='30' x='115'>Apple</text>
+            <path id='path' d='M 200 26 L 600 26' stroke='red' stroke-width='1em'/>
+          </svg>
+        </body>
+      </html>
+    );
+  }
+});
+
+var document = Helper.render(<Doc/>);
 
 var assertEvaluatesToNodeSet = Helper.assertEvaluatesToNodeSet.bind(null, document);
 

--- a/test/math_test.js
+++ b/test/math_test.js
@@ -4,14 +4,20 @@ var React = require("react");
 
 var Helper = require("./helper");
 
-var document = (
-  <html>
-    <body>
-      <div id='with' price='2' count='3'></div>
-      <div id='without' price='2' count='4'></div>
-    </body>
-  </html>
-);
+var Doc = React.createClass({
+  render: function () {
+    return (
+      <html>
+        <body>
+          <div id='with' price='2' count='3'></div>
+          <div id='without' price='2' count='4'></div>
+        </body>
+      </html>
+    );
+  }
+});
+
+var document = Helper.render(<Doc/>);
 
 var assertEvaluatesToNodeSet = Helper.assertEvaluatesToNodeSet.bind(null, document);
 

--- a/test/misc_test.js
+++ b/test/misc_test.js
@@ -4,47 +4,53 @@ var React = require("react");
 
 var Helper = require("./helper");
 
-var document = (
-  <html>
-    <body>
-      <div id='id1'>foo</div>
-      <div id='id2'>bar</div>
-      <div id='id3'>baz</div>
-      <div id='id4'>
-        <div id='id4-1'>foo</div>
-        <div id='id4-2'>bar</div>
-        <div id='id4-3'>baz</div>
-      </div>
-      <table>
-        <tbody>
-          <tr id='id5'>
-            <td>1</td> <td>2</td>
-          </tr>
-          <tr id='id6'>
-            <td>1</td> <td>2</td>
-          </tr>
-          <tr id='id7'>
-            <td>1</td> <td>2</td>
-          </tr>
-        </tbody>
-      </table>
-      <table>
-        <tbody>
-          <tr id='id8'>
-            <td>1</td> <td>2</td>
-          </tr>
-          <tr id='id9'>
-            <td>1</td> <td>2</td>
-          </tr>
-          <tr id='id0'>
-            <td>1</td> <td>2</td>
-          </tr>
-        </tbody>
-      </table>
-      <p id='ppp'>1</p>
-    </body>
-  </html>
-);
+var Doc = React.createClass({
+  render: function () {
+    return (
+      <html>
+        <body>
+          <div id='id1'>foo</div>
+          <div id='id2'>bar</div>
+          <div id='id3'>baz</div>
+          <div id='id4'>
+            <div id='id4-1'>foo</div>
+            <div id='id4-2'>bar</div>
+            <div id='id4-3'>baz</div>
+          </div>
+          <table>
+            <tbody>
+              <tr id='id5'>
+                <td>1</td> <td>2</td>
+              </tr>
+              <tr id='id6'>
+                <td>1</td> <td>2</td>
+              </tr>
+              <tr id='id7'>
+                <td>1</td> <td>2</td>
+              </tr>
+            </tbody>
+          </table>
+          <table>
+            <tbody>
+              <tr id='id8'>
+                <td>1</td> <td>2</td>
+              </tr>
+              <tr id='id9'>
+                <td>1</td> <td>2</td>
+              </tr>
+              <tr id='id0'>
+                <td>1</td> <td>2</td>
+              </tr>
+            </tbody>
+          </table>
+          <p id='ppp'>1</p>
+        </body>
+      </html>
+    );
+  }
+});
+
+var document = Helper.render(<Doc/>);
 
 var assertEvaluatesToNodeSet = Helper.assertEvaluatesToNodeSet.bind(null, document);
 

--- a/test/name_test.js
+++ b/test/name_test.js
@@ -4,16 +4,22 @@ var React = require("react");
 
 var Helper = require("./helper");
 
-var document = (
-  <html>
-    <body>
-      <div name='single' id='single'>div element 1</div>
-      <div name='duplicate' id='duplicate_1'>div element 2</div>
-      <div name='duplicate' id='duplicate_2'>div element 3</div>
-      <div name='duplicate' id='duplicate_3'>div element 4</div>
-    </body>
-  </html>
-);
+var Doc = React.createClass({
+  render: function () {
+    return (
+      <html>
+        <body>
+          <div name='single' id='single'>div element 1</div>
+          <div name='duplicate' id='duplicate_1'>div element 2</div>
+          <div name='duplicate' id='duplicate_2'>div element 3</div>
+          <div name='duplicate' id='duplicate_3'>div element 4</div>
+        </body>
+      </html>
+    );
+  }
+});
+
+var document = Helper.render(<Doc/>);
 
 var assertEvaluatesToNodeSet = Helper.assertEvaluatesToNodeSet.bind(null, document);
 

--- a/test/perf/application.js
+++ b/test/perf/application.js
@@ -10,7 +10,7 @@ var ReactDOM = require("react-dom");
 
 var TestUtils = require("react-addons-test-utils");
 
-var XPathReact = require("../../register");
+var XPathReact = require("../../index");
 
 var Suite = new Benchmark.Suite();
 

--- a/test/preceding_and_following_test.js
+++ b/test/preceding_and_following_test.js
@@ -4,33 +4,39 @@ var React = require("react");
 
 var Helper = require("./helper");
 
-var document = (
-  <html>
-    <head>
-      <title>title</title>
-    </head>
-    <body>
-      <div>
-        <p className='1'></p>
-        <ul>
-          <li id='t1'></li>
-          <li></li>
-          <li id='t2'></li>
-        </ul>
-        <p className='2'></p>
-      </div>
-      <div>
-       <p className='3'></p>
-       <ul>
-         <li id='t3'></li>
-         <li></li>
-         <li id='t4'></li>
-       </ul>
-       <p className='4'></p>
-      </div>
-    </body>
-  </html>
-);
+var Doc = React.createClass({
+  render: function () {
+    return (
+      <html>
+        <head>
+          <title>title</title>
+        </head>
+        <body>
+          <div>
+            <p className='1'></p>
+            <ul>
+              <li id='t1'></li>
+              <li></li>
+              <li id='t2'></li>
+            </ul>
+            <p className='2'></p>
+          </div>
+          <div>
+           <p className='3'></p>
+           <ul>
+             <li id='t3'></li>
+             <li></li>
+             <li id='t4'></li>
+           </ul>
+           <p className='4'></p>
+          </div>
+        </body>
+      </html>
+    );
+  }
+});
+
+var document = Helper.render(<Doc/>);
 
 var assertEvaluatesToNodeSet = Helper.assertEvaluatesToNodeSet.bind(null, document);
 

--- a/test/sibling_test.js
+++ b/test/sibling_test.js
@@ -4,16 +4,22 @@ var React = require("react");
 
 var Helper = require("./helper");
 
-var document = (
-  <html>
-    <head>
-      <title>title</title>
-    </head>
-    <body>
-      <div><span id='first' className='1'></span>foo<span className='2'></span>bar<span className='3'></span>baz<span id='last' className='4'></span></div>
-    </body>
-  </html>
-);
+var Doc = React.createClass({
+  render: function () {
+    return (
+      <html>
+        <head>
+          <title>title</title>
+        </head>
+        <body>
+          <div><span id='first' className='1'></span>foo<span className='2'></span>bar<span className='3'></span>baz<span id='last' className='4'></span></div>
+        </body>
+      </html>
+    );
+  }
+});
+
+var document = Helper.render(<Doc/>);
 
 var assertEvaluatesToNodeSet = Helper.assertEvaluatesToNodeSet.bind(null, document);
 

--- a/test/simple_value_test.js
+++ b/test/simple_value_test.js
@@ -4,26 +4,32 @@ var React = require("react");
 
 var Helper = require("./helper");
 
-var document = (
-  <html>
-    <head>
-      <title>Title</title>
-    </head>
-    <body>
-      <div>
-        <span id='a'>hoge</span>
-        <span id='b'>3</span>
-      </div>
-      <ol id='numbers'>
-        <li>1</li>
-        <li>2</li>
-        <li>3</li>
-        <li>4</li>
-        <li>5</li>
-      </ol>
-    </body>
-  </html>
-);
+var Doc = React.createClass({
+  render: function () {
+    return (
+      <html>
+        <head>
+          <title>Title</title>
+        </head>
+        <body>
+          <div>
+            <span id='a'>hoge</span>
+            <span id='b'>3</span>
+          </div>
+          <ol id='numbers'>
+            <li>1</li>
+            <li>2</li>
+            <li>3</li>
+            <li>4</li>
+            <li>5</li>
+          </ol>
+        </body>
+      </html>
+    );
+  }
+});
+
+var document = Helper.render(<Doc/>);
 
 var DOCUMENT_AS_STRING = "Titlehoge312345";
 

--- a/test/sort_and_merge_test.js
+++ b/test/sort_and_merge_test.js
@@ -4,27 +4,33 @@ var React = require("react");
 
 var Helper = require("./helper");
 
-var document = (
-  <html>
-    <head>
-      <title>Title</title>
-    </head>
-    <body>
-      <ul id='container'>
-        <li id='li-1'></li>
-        <li id='li-2'></li>
-        <li id='li-3'></li>
-        <li id='li-4'></li>
-      </ul>
-      <ul id='container-0'>
-        <li id='li-5'></li>
-        <li id='li-6'></li>
-        <li id='li-7'></li>
-        <li id='li-8'></li>
-      </ul>
-    </body>
-  </html>
-);
+var Doc = React.createClass({
+  render: function () {
+    return (
+      <html>
+        <head>
+          <title>Title</title>
+        </head>
+        <body>
+          <ul id='container'>
+            <li id='li-1'></li>
+            <li id='li-2'></li>
+            <li id='li-3'></li>
+            <li id='li-4'></li>
+          </ul>
+          <ul id='container-0'>
+            <li id='li-5'></li>
+            <li id='li-6'></li>
+            <li id='li-7'></li>
+            <li id='li-8'></li>
+          </ul>
+        </body>
+      </html>
+    );
+  }
+});
+
+var document = Helper.render(<Doc/>);
 
 var assertEvaluatesToNodeSet = Helper.assertEvaluatesToNodeSet.bind(null, document);
 

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -4,6 +4,8 @@ var Assert = require("assert");
 
 var XPathUtils = require("../utils");
 
+var Helper = require("./helper");
+
 var React = require("react");
 
 var Foo = React.createClass({
@@ -27,7 +29,7 @@ describe("XPathReact", function () {
   describe("Utils", function () {
     describe("render()", function () {
       it("should create a shallow rendering of a component", function () {
-        var output = Helper.render(<Foo />);
+        var output = \.render(<Foo />);
 
         Assert.equal(output.props.children[0].props.children, "Hello world!");
       });

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -29,7 +29,7 @@ describe("XPathReact", function () {
   describe("Utils", function () {
     describe("render()", function () {
       it("should create a shallow rendering of a component", function () {
-        var output = \.render(<Foo />);
+        var output = Helper.render(<Foo />);
 
         Assert.equal(output.props.children[0].props.children, "Hello world!");
       });

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -4,10 +4,7 @@ var Assert = require("assert");
 
 var XPathUtils = require("../utils");
 
-var Helper = require("./helper");
-
 var React = require("react");
-var ReactTestUtils = require("react-addons-test-utils");
 
 var Foo = React.createClass({
   propTypes: {

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -4,7 +4,10 @@ var Assert = require("assert");
 
 var XPathUtils = require("../utils");
 
+var Helper = require("./helper");
+
 var React = require("react");
+var ReactTestUtils = require("react-addons-test-utils");
 
 var Foo = React.createClass({
   propTypes: {
@@ -27,7 +30,7 @@ describe("XPathReact", function () {
   describe("Utils", function () {
     describe("render()", function () {
       it("should create a shallow rendering of a component", function () {
-        var output = XPathUtils.render(<Foo />);
+        var output = Helper.render(<Foo />);
 
         Assert.equal(output.props.children[0].props.children, "Hello world!");
       });
@@ -35,15 +38,15 @@ describe("XPathReact", function () {
 
     describe("find()", function () {
       it("should return the first element matching the expression", function () {
-        var output = XPathUtils.render(<Foo />);
+        var output = Helper.render(<Foo />);
 
         var p = XPathUtils.find(output, ".//p");
 
         Assert.equal(p.props.children, "Hello world!");
       });
 
-      it("should return null when no elements match the expression", function () {
-        var output = XPathUtils.render(<Foo />);
+      it("should return empty array when no elements match the expression", function () {
+        var output = Helper.render(<Foo />);
 
         var ul = XPathUtils.find(output, ".//ul");
 
@@ -51,7 +54,7 @@ describe("XPathReact", function () {
       });
 
       it("should support returning string types", function () {
-        var output = XPathUtils.render(<Foo />);
+        var output = Helper.render(<Foo />);
 
         var buttonText = XPathUtils.find(output, "string(.//p)");
 
@@ -59,7 +62,7 @@ describe("XPathReact", function () {
       });
 
       it("should support returning number types", function () {
-        var output = XPathUtils.render(<Foo />);
+        var output = Helper.render(<Foo />);
 
         var nButtons = XPathUtils.find(output, "count(.//button)");
 
@@ -67,7 +70,7 @@ describe("XPathReact", function () {
       });
 
       it("should support returning boolean types", function () {
-        var output = XPathUtils.render(<Foo />);
+        var output = Helper.render(<Foo />);
 
         var hasBarButton = XPathUtils.find(output, "count(.//button[contains(., 'Bar')]) = 1");
 
@@ -94,49 +97,21 @@ describe("XPathReact", function () {
             }
           };
 
-          var output = XPathUtils.render(<Foo onClick={onClick} />);
+          var output = Helper.render(<Foo onClick={onClick} />);
 
           var button = XPathUtils.find(output, ".//button");
 
-          XPathUtils.Simulate.click(button, {foo: "bar"});
+          Assert.equal(XPathUtils.simulate(button, "click", {foo: "bar"}), true);
 
           Assert.equal(wasInvoked, true);
         });
 
-        it("should throw an error when no event handler is present", function () {
-          Assert.throws(function () {
-            var output = XPathUtils.render(<Foo />);
+        it("should return false when no event handler is present", function () {
+          var output = Helper.render(<Foo />);
 
-            var button = XPathUtils.find(output, ".//button");
+          var button = XPathUtils.find(output, ".//button");
 
-            XPathUtils.Simulate.mouseDown(button);
-          }, /No event handler for onMouseDown/);
-        });
-      });
-
-      describe("when also provided with an XPath expression", function () {
-        it("should invoke the event handler of the matching element", function () {
-          var wasInvoked = false;
-
-          var onClick = function (e) {
-            if (e.foo === "bar") {
-              wasInvoked = true;
-            }
-          };
-
-          var output = XPathUtils.render(<Foo onClick={onClick} />);
-
-          XPathUtils.Simulate.click(output, ".//button", {foo: "bar"});
-
-          Assert.equal(wasInvoked, true);
-        });
-
-        it("should throw an error when no event handler is present", function () {
-          Assert.throws(function () {
-            var output = XPathUtils.render(<Foo />);
-
-            XPathUtils.Simulate.mouseDown(output, ".//button");
-          }, /No event handler for onMouseDown/);
+          Assert.equal(XPathUtils.simulate(button, "mousedown"), false);
         });
       });
     });

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -4,9 +4,18 @@ var Assert = require("assert");
 
 var XPathUtils = require("../utils");
 
+var React = require("react");
+var ReactDom = require("react-dom");
+
 var Helper = require("./helper");
 
-var React = require("react");
+var jsdom = require("jsdom");
+
+function initDOM() {
+  global.document = jsdom.jsdom("");
+  global.window = document.defaultView;
+  global.navigator = window.navigator;
+}
 
 var Foo = React.createClass({
   propTypes: {
@@ -27,15 +36,8 @@ var Foo = React.createClass({
 
 describe("XPathReact", function () {
   describe("Utils", function () {
-    describe("render()", function () {
-      it("should create a shallow rendering of a component", function () {
-        var output = Helper.render(<Foo />);
 
-        Assert.equal(output.props.children[0].props.children, "Hello world!");
-      });
-    });
-
-    describe("find()", function () {
+    describe("find() in shallow rendered", function () {
       it("should return the first element matching the expression", function () {
         var output = Helper.render(<Foo />);
 
@@ -85,7 +87,70 @@ describe("XPathReact", function () {
       });
     });
 
-    describe("Simulate.<event>()", function () {
+    describe("find() in dom rendered", function () {
+      it("should return the first element matching the expression", function () {
+        initDOM();
+
+        var div = document.createElement("div");
+        document.body.appendChild(div);
+        var output = ReactDom.render(<Foo />, div);
+
+        var p = XPathUtils.find(output, ".//p");
+
+        Assert.equal(p.tagName, "P");
+      });
+
+      it("should return empty array when no elements match the expression", function () {
+        initDOM();
+
+        var div = document.createElement("div");
+        document.body.appendChild(div);
+        var output = ReactDom.render(<Foo />, div);
+
+        var ul = XPathUtils.find(output, ".//ul");
+
+        Assert.equal(ul, null);
+      });
+
+      it("should support returning string types", function () {
+        initDOM();
+
+        var div = document.createElement("div");
+        document.body.appendChild(div);
+        var output = ReactDom.render(<Foo />, div);
+
+        var buttonText = XPathUtils.find(output, "string(.//p)");
+
+        Assert.equal(buttonText, "Hello world!");
+      });
+
+      it("should support returning number types", function () {
+        initDOM();
+
+        var div = document.createElement("div");
+        document.body.appendChild(div);
+        var output = ReactDom.render(<Foo />, div);
+
+        var nButtons = XPathUtils.find(output, "count(.//button)");
+
+        Assert.equal(nButtons, 1);
+      });
+
+      it("should support returning boolean types", function () {
+        initDOM();
+
+        var div = document.createElement("div");
+        document.body.appendChild(div);
+        var output = ReactDom.render(<Foo />, div);
+
+        var hasBarButton = XPathUtils.find(output, "count(.//button[contains(., 'Bar')]) = 1");
+
+        Assert.equal(hasBarButton, true);
+      });
+
+    });
+
+    describe("simulate()", function () {
       describe("when provided with a React element", function () {
         it("should invoke the event handler of the element", function () {
           var wasInvoked = false;

--- a/utils.js
+++ b/utils.js
@@ -86,9 +86,9 @@ var XPathUtils = {
     }
   },
 
-  findReactRoot: function(path) {
-    var xpath = path || '//*[@data-reactroot]';
-    var xpathResult = document.evaluate(xpath, document, null, XPathEvaluator.XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE, null);
+  findReactRoot: function(path, element) {
+    var xpath = path || './/*[@data-reactroot]';
+    var xpathResult = window.document.evaluate(xpath, element || window.document.documentElement, null, XPathEvaluator.XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE, null);
     if (xpathResult.snapshotLength == 0) {
         throw 'No react application root was found with path ' + xpath;
     } else if (xpathResult.snapshotLength > 1) {

--- a/utils.js
+++ b/utils.js
@@ -12,7 +12,7 @@ var ALL_EVENTS = {
   keypress: "onKeyPress",
   contextmenu: "onContextMenu",
   dblclick: "onDoubleClick",
-  doubleclick: "onDoubleClick", // kept for legacy. TODO: remove with next major.
+  doubleclick: "onDoubleClick",
   dragend: "onDragEnd",
   dragenter: "onDragEnter",
   dragexist: "onDragExit",

--- a/utils.js
+++ b/utils.js
@@ -4,45 +4,45 @@ var XPathEvaluator = require("./index");
 var ReactInternals = require("./lib/ReactInternals");
 
 var ALL_EVENTS = {
-  compositionend: 'onCompositionEnd',
-  compositionstart: 'onCompositionStart',
-  compositionupdate: 'onCompositionUpdate',
-  keydown: 'onKeyDown',
-  keyup: 'onKeyUp',
-  keypress: 'onKeyPress',
-  contextmenu: 'onContextMenu',
-  dblclick: 'onDoubleClick',
-  doubleclick: 'onDoubleClick', // kept for legacy. TODO: remove with next major.
-  dragend: 'onDragEnd',
-  dragenter: 'onDragEnter',
-  dragexist: 'onDragExit',
-  dragleave: 'onDragLeave',
-  dragover: 'onDragOver',
-  dragstart: 'onDragStart',
-  mousedown: 'onMouseDown',
-  mouseenter: 'onMouseEnter',
-  mouseleave: 'onMouseLeave',
-  mousemove: 'onMouseMove',
-  mouseout: 'onMouseOut',
-  mouseover: 'onMouseOver',
-  mouseup: 'onMouseUp',
-  touchcancel: 'onTouchCancel',
-  touchend: 'onTouchEnd',
-  touchmove: 'onTouchMove',
-  touchstart: 'onTouchStart',
-  canplay: 'onCanPlay',
-  canplaythrough: 'onCanPlayThrough',
-  durationchange: 'onDurationChange',
-  loadeddata: 'onLoadedData',
-  loadedmetadata: 'onLoadedMetadata',
-  loadstart: 'onLoadStart',
-  ratechange: 'onRateChange',
-  timeupdate: 'onTimeUpdate',
-  volumechange: 'onVolumeChange',
+  compositionend: "onCompositionEnd",
+  compositionstart: "onCompositionStart",
+  compositionupdate: "onCompositionUpdate",
+  keydown: "onKeyDown",
+  keyup: "onKeyUp",
+  keypress: "onKeyPress",
+  contextmenu: "onContextMenu",
+  dblclick: "onDoubleClick",
+  doubleclick: "onDoubleClick", // kept for legacy. TODO: remove with next major.
+  dragend: "onDragEnd",
+  dragenter: "onDragEnter",
+  dragexist: "onDragExit",
+  dragleave: "onDragLeave",
+  dragover: "onDragOver",
+  dragstart: "onDragStart",
+  mousedown: "onMouseDown",
+  mouseenter: "onMouseEnter",
+  mouseleave: "onMouseLeave",
+  mousemove: "onMouseMove",
+  mouseout: "onMouseOut",
+  mouseover: "onMouseOver",
+  mouseup: "onMouseUp",
+  touchcancel: "onTouchCancel",
+  touchend: "onTouchEnd",
+  touchmove: "onTouchMove",
+  touchstart: "onTouchStart",
+  canplay: "onCanPlay",
+  canplaythrough: "onCanPlayThrough",
+  durationchange: "onDurationChange",
+  loadeddata: "onLoadedData",
+  loadedmetadata: "onLoadedMetadata",
+  loadstart: "onLoadStart",
+  ratechange: "onRateChange",
+  timeupdate: "onTimeUpdate",
+  volumechange: "onVolumeChange"
 };
 
 function handlerNameFromEvent(event) {
-  return ALL_EVENTS[event] || 'on' + event.charAt(0).toUpperCase() + event.slice(1);
+  return ALL_EVENTS[event] || "on" + event.charAt(0).toUpperCase() + event.slice(1);
 }
 
 var XPathUtils = {
@@ -71,7 +71,7 @@ var XPathUtils = {
           results.push(el);
         }
         if (results.length > 1) {
-          throw 'Found multiple results with expression' + expression;
+          throw "Found multiple results with expression" + expression;
         }
         return results[0];
         
@@ -87,12 +87,12 @@ var XPathUtils = {
   },
 
   findReactRoot: function(path, element) {
-    var xpath = path || './/*[@data-reactroot]';
+    var xpath = path || ".//*[@data-reactroot]";
     var xpathResult = window.document.evaluate(xpath, element || window.document.documentElement, null, XPathEvaluator.XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE, null);
     if (xpathResult.snapshotLength == 0) {
-        throw 'No react application root was found with path ' + xpath;
+      throw "No react application root was found with path " + xpath;
     } else if (xpathResult.snapshotLength > 1) {
-        throw 'Multiple react application roots were found with path ' + xpath;
+      throw "Multiple react application roots were found with path " + xpath;
     }
     return ReactInternals.findTopLevelCompositeComponentAtDOMNode(xpathResult.snapshotItem(0));
   },

--- a/utils.js
+++ b/utils.js
@@ -41,6 +41,8 @@ var ALL_EVENTS = {
   volumechange: "onVolumeChange"
 };
 
+var REACT_15_ROOT_XPATH = ".//*[@data-reactroot]";
+
 function handlerNameFromEvent(event) {
   return ALL_EVENTS[event] || "on" + event.charAt(0).toUpperCase() + event.slice(1);
 }
@@ -88,8 +90,9 @@ var XPathUtils = {
   },
 
   findReactRoot: function(path, element) {
-    var xpath = path || ".//*[@data-reactroot]";
-    var xpathResult = window.document.evaluate(xpath, element || window.document.documentElement, null, XPathEvaluator.XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE, null);
+    // default to react 15.x xpath
+    var xpath = path || REACT_15_ROOT_XPATH;
+    var xpathResult = window.document.evaluate(xpath, element || window.document.documentElement, null, window.XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
     if (xpathResult.snapshotLength == 0) {
       throw "No react application root was found with path " + xpath;
     } else if (xpathResult.snapshotLength > 1) {

--- a/utils.js
+++ b/utils.js
@@ -1,55 +1,109 @@
 "use strict";
 
-var TestUtils = require("react-addons-test-utils");
+var XPathEvaluator = require("./index");
+var ReactInternals = require("./lib/ReactInternals");
 
-var XPath = require("./register");
+var ALL_EVENTS = {
+  compositionend: 'onCompositionEnd',
+  compositionstart: 'onCompositionStart',
+  compositionupdate: 'onCompositionUpdate',
+  keydown: 'onKeyDown',
+  keyup: 'onKeyUp',
+  keypress: 'onKeyPress',
+  contextmenu: 'onContextMenu',
+  dblclick: 'onDoubleClick',
+  doubleclick: 'onDoubleClick', // kept for legacy. TODO: remove with next major.
+  dragend: 'onDragEnd',
+  dragenter: 'onDragEnter',
+  dragexist: 'onDragExit',
+  dragleave: 'onDragLeave',
+  dragover: 'onDragOver',
+  dragstart: 'onDragStart',
+  mousedown: 'onMouseDown',
+  mouseenter: 'onMouseEnter',
+  mouseleave: 'onMouseLeave',
+  mousemove: 'onMouseMove',
+  mouseout: 'onMouseOut',
+  mouseover: 'onMouseOver',
+  mouseup: 'onMouseUp',
+  touchcancel: 'onTouchCancel',
+  touchend: 'onTouchEnd',
+  touchmove: 'onTouchMove',
+  touchstart: 'onTouchStart',
+  canplay: 'onCanPlay',
+  canplaythrough: 'onCanPlayThrough',
+  durationchange: 'onDurationChange',
+  loadeddata: 'onLoadedData',
+  loadedmetadata: 'onLoadedMetadata',
+  loadstart: 'onLoadStart',
+  ratechange: 'onRateChange',
+  timeupdate: 'onTimeUpdate',
+  volumechange: 'onVolumeChange',
+};
 
-module.exports = {
-  render: function (component) {
-    var renderer = TestUtils.createRenderer();
-    renderer.render(component);
-    return renderer.getRenderOutput();
+function handlerNameFromEvent(event) {
+  return ALL_EVENTS[event] || 'on' + event.charAt(0).toUpperCase() + event.slice(1);
+}
+
+var XPathUtils = {
+
+  XPathResult: XPathEvaluator.XPathResult,
+
+  evaluate: function(expression, element, type) {
+    return XPathEvaluator.evaluate(expression, element, null, type);
   },
 
-  find: function (element, expression) {
-    var result = XPath.evaluate(
-      expression,
-      element,
-      null,
-      XPath.XPathResult.ANY_TYPE, null);
+  find: function(element, expression) {
+    // check params and swap if necessary
+    if (typeof element === "string") {
+      var tmp = element;
+      element = expression;
+      expression = tmp;
+    }
+
+    var result = XPathEvaluator.evaluate(expression, element, null, XPathEvaluator.XPathResult.ANY_TYPE);
 
     switch (result.resultType) {
-      case XPath.XPathResult.UNORDERED_NODE_ITERATOR_TYPE:
-        return result.iterateNext();
-
-      case XPath.XPathResult.STRING_TYPE:
+      case XPathEvaluator.XPathResult.UNORDERED_NODE_ITERATOR_TYPE:
+        var results = [];
+        var el;
+        while (el = result.iterateNext()) {
+          results.push(el);
+        }
+        if (results.length > 1) {
+          throw 'Found multiple results with expression' + expression;
+        }
+        return results[0];
+        
+      case XPathEvaluator.XPathResult.STRING_TYPE:
         return result.stringValue;
 
-      case XPath.XPathResult.NUMBER_TYPE:
+      case XPathEvaluator.XPathResult.NUMBER_TYPE:
         return result.numberValue;
 
-      case XPath.XPathResult.BOOLEAN_TYPE:
+      case XPathEvaluator.XPathResult.BOOLEAN_TYPE:
         return result.booleanValue;
     }
   },
 
-  Simulate: Object.keys(TestUtils.Simulate).reduce(function (simulate, event) {
-    simulate[event] = function (element, expression, eventData) {
-      if (typeof expression === "string") {
-        element = module.exports.find(element, expression);
-      } else {
-        eventData = expression;
-      }
+  findReactRoot: function(path) {
+    var xpath = path || '//*[@data-reactroot]';
+    var xpathResult = document.evaluate(xpath, document, null, XPathEvaluator.XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE, null);
+    if (xpathResult.snapshotLength == 0) {
+        throw 'No react application root was found with path ' + xpath;
+    } else if (xpathResult.snapshotLength > 1) {
+        throw 'Multiple react application roots were found with path ' + xpath;
+    }
+    return ReactInternals.findTopLevelCompositeComponentAtDOMNode(xpathResult.snapshotItem(0));
+  },
 
-      var eventName = "on" + event.charAt(0).toUpperCase() + event.slice(1);
+  simulate: function(element, event, eventData) {
+    var eventName = handlerNameFromEvent(event);
+    var handler = element.props[eventName];
+    handler && handler(eventData);
+    return !!handler;
+  }
 
-      if (element.props[eventName]) {
-        element.props[eventName](eventData);
-      } else {
-        throw new Error("No event handler for " + eventName);
-      }
-    };
-
-    return simulate;
-  }, {})
 };
+
+module.exports = XPathUtils;

--- a/utils.js
+++ b/utils.js
@@ -66,9 +66,10 @@ var XPathUtils = {
     switch (result.resultType) {
       case XPathEvaluator.XPathResult.UNORDERED_NODE_ITERATOR_TYPE:
         var results = [];
-        var el;
-        while (el = result.iterateNext()) {
+        var el = result.iterateNext();
+        while (el) {
           results.push(el);
+          el = result.iterateNext();
         }
         if (results.length > 1) {
           throw "Found multiple results with expression" + expression;

--- a/utils.js
+++ b/utils.js
@@ -41,8 +41,6 @@ var ALL_EVENTS = {
   volumechange: "onVolumeChange"
 };
 
-var REACT_15_ROOT_XPATH = ".//*[@data-reactroot]";
-
 function handlerNameFromEvent(event) {
   return ALL_EVENTS[event] || "on" + event.charAt(0).toUpperCase() + event.slice(1);
 }
@@ -56,7 +54,7 @@ var XPathUtils = {
   },
 
   find: function(element, expression) {
-    // check params and swap if necessary
+    // check params and swap if necessary, since parameters are in reverse order to evaluate()
     if (typeof element === "string") {
       var tmp = element;
       element = expression;
@@ -68,10 +66,9 @@ var XPathUtils = {
     switch (result.resultType) {
       case XPathEvaluator.XPathResult.UNORDERED_NODE_ITERATOR_TYPE:
         var results = [];
-        var el = result.iterateNext();
-        while (el) {
+        var el;
+        while (el = result.iterateNext()) {
           results.push(el);
-          el = result.iterateNext();
         }
         if (results.length > 1) {
           throw "Found multiple results with expression" + expression;
@@ -90,8 +87,7 @@ var XPathUtils = {
   },
 
   findReactRoot: function(path, element) {
-    // default to react 15.x xpath
-    var xpath = path || REACT_15_ROOT_XPATH;
+    var xpath = path || ".//*[@data-reactroot]";
     var xpathResult = window.document.evaluate(xpath, element || window.document.documentElement, null, window.XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
     if (xpathResult.snapshotLength == 0) {
       throw "No react application root was found with path " + xpath;

--- a/utils.js
+++ b/utils.js
@@ -67,7 +67,7 @@ var XPathUtils = {
       case XPathEvaluator.XPathResult.UNORDERED_NODE_ITERATOR_TYPE:
         var results = [];
         var el;
-        while (!!(el = result.iterateNext())) {
+        while ((el = result.iterateNext())) {
           results.push(el);
         }
         if (results.length > 1) {

--- a/utils.js
+++ b/utils.js
@@ -67,7 +67,7 @@ var XPathUtils = {
       case XPathEvaluator.XPathResult.UNORDERED_NODE_ITERATOR_TYPE:
         var results = [];
         var el;
-        while (el = result.iterateNext()) {
+        while (!!(el = result.iterateNext())) {
           results.push(el);
         }
         if (results.length > 1) {


### PR DESCRIPTION
Did the following changes:

- Update react_element to handle both elements and composite components. This enables it's use in the dom and allows it to traverse the whole rendered subtree, not just the declared children. We have added a selenium selector using this update to allow us to select react components using a react xpath in selenium tests
- removed dependency on react-test-utils and instead added some code in ReactInternals.js to handle internal react operations to traverse the rendered component tree. This was also done to make the js payload sent by selenium to the target page small. This also required a change to the simulate api in utils.js)
- removed the render method from utils as that was just a simplification on the react test utils api from 3 lines to 1 line and also to remove the dependency on react-test-utils
- changed tests to render the elements rather than use them directly

any comments / suggestions welcome, and feel free to request clarifications, changes etc.